### PR TITLE
Migrate to @solana/kit + ESM (clears all advisories)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,8 @@ USER_KEYPAIR=/home/you/.config/solana/id.json
 # Execute real trades. false = simulation mode (quotes only, no swaps)
 ENABLE_TRADING=false
 
-# Optional: Jupiter API base URL
-#JUPITER_API_BASE_URL=https://quote-api.jup.ag/v6
+# Optional: Jupiter API base URL (free tier; paid tier: https://api.jup.ag/swap/v1)
+#JUPITER_API_BASE_URL=https://lite-api.jup.ag/swap/v1
 
 # Optional strategy overrides (defaults shown)
 #MM_WAIT_TIME_MS=60000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,17 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
       - run: npm run build
       - run: npm run lint
       - run: npm test
+      - run: npm audit --audit-level=high

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 - `npm run build` - Compile TypeScript to JavaScript
 - `npm start` - Run the compiled bot (production)
-- `npm run dev` - Run the bot with ts-node (development)
+- `npm run dev` - Run the bot with tsx (development)
 - `npm test` - Run unit tests (Vitest)
 - `npm run lint` - Lint src and tests (ESLint)
 
@@ -35,7 +35,8 @@
 
 ## Dependencies
 
-- Solana web3.js and SPL Token
+- `@solana/kit` (modern Solana SDK, formerly web3.js v2) and `@solana-program/token`
 - Jupiter Aggregator HTTP API (v6)
-- TypeScript and Node.js (v18+)
-- Vitest for testing, ESLint (typescript-eslint) for linting
+- ESM-only project (`"type": "module"`, `tsconfig` `module: nodenext`); relative imports must carry a `.js` extension
+- TypeScript and Node.js (v20+; kit's signer uses WebCrypto Ed25519)
+- Vitest for testing, ESLint (typescript-eslint) for linting, tsx for `npm run dev`

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ This project is a Solana Market Maker Bot designed to automate trading strategie
 ├── eslint.config.mjs
 ├── .env.example                # Template for environment configuration
 ├── .github
-│   └── workflows/ci.yml        # CI: build, lint, test
+│   └── workflows/ci.yml        # CI: build, lint, test, audit (Node 20 & 22)
 ├── src
 │   ├── api
 │   │   ├── jupiter.ts          # Jupiter API client with quote and swap functionality
-│   │   └── solana.ts           # Solana connection management and mint helpers
+│   │   └── solana.ts           # Solana RPC client (@solana/kit) and mint helpers
 │   ├── constants
 │   │   └── constants.ts        # Token mint addresses
 │   ├── main.ts                 # Entry point and setup
@@ -41,7 +41,7 @@ This project is a Solana Market Maker Bot designed to automate trading strategie
 │   │   ├── convert.ts          # Token unit conversion utilities (Decimal-based)
 │   │   ├── transactionSender.ts # Robust transaction submission with retry logic
 │   │   └── sleep.ts            # Asynchronous sleep utility
-│   └── wallet.ts               # Keypair loading from file or mnemonic
+│   └── wallet.ts               # Signer loading (@solana/kit) from file or mnemonic
 └── tests                       # Vitest unit tests
     ├── basicMM.test.ts
     └── convert.test.ts
@@ -49,7 +49,7 @@ This project is a Solana Market Maker Bot designed to automate trading strategie
 
 ## Requirements
 
-- Node.js (version 18.x or later)
+- Node.js (version 20.x or later; the `@solana/kit` signer relies on WebCrypto Ed25519)
 - A funded Solana wallet with SOL and SPL tokens
 
 ## Setup
@@ -77,7 +77,7 @@ This project is a Solana Market Maker Bot designed to automate trading strategie
 | `USER_KEYPAIR`               | no\*     | Path to a JSON secret-key file (solana-keygen format)                          |
 | `SOLANA_MNEMONIC`            | no\*     | BIP39 mnemonic to derive the keypair from                                      |
 | `ENABLE_TRADING`             | no       | `true` to execute real swaps; anything else runs in simulation mode            |
-| `JUPITER_API_BASE_URL`       | no       | Override the Jupiter API base URL (default: `https://quote-api.jup.ag/v6`)     |
+| `JUPITER_API_BASE_URL`       | no       | Override the Jupiter API base URL (default: `https://lite-api.jup.ag/swap/v1`) |
 | `MM_WAIT_TIME_MS`            | no       | Milliseconds between rebalance checks (default: `60000`)                       |
 | `MM_SLIPPAGE_BPS`            | no       | Maximum slippage in basis points (default: `50`)                               |
 | `MM_PRICE_TOLERANCE`         | no       | Portfolio imbalance fraction required to trigger a rebalance (default: `0.02`) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,50 +9,60 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@solana/spl-token": "^0.4.6",
-        "@solana/web3.js": "^1.91.1",
+        "@solana-program/token": "^0.14.0",
+        "@solana/kit": "^6.10.0",
         "bip39": "^3.1.0",
-        "bs58": "^5.0.0",
-        "cross-fetch": "^4.0.0",
         "decimal.js": "^10.4.3",
-        "dotenv": "^16.4.5",
-        "ed25519-hd-key": "^1.3.0",
+        "dotenv": "^17.4.2",
+        "ed25519-hd-key": "^2.0.0",
         "promise-retry": "^2.0.1",
         "tweetnacl": "^1.0.3"
       },
       "devDependencies": {
-        "@types/node": "^20.12.7",
+        "@types/node": "^24.0.0",
         "@types/promise-retry": "^1.1.6",
-        "eslint": "^9.9.0",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.4.5",
-        "typescript-eslint": "^8.0.0",
-        "vitest": "^3.2.6"
+        "eslint": "^10.6.0",
+        "tsx": "^4.23.0",
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.63.0",
+        "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
-    "node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
-      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -540,105 +550,68 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
-      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@humanfs/core": {
@@ -707,16 +680,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
@@ -724,28 +687,30 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+    "node_modules/@noble/ed25519": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-3.1.0.tgz",
+      "integrity": "sha512-pfcObRY3CtvwfaG9Mt5XqZdKmAQppl37tHUeuBhDUbiwJBCVY4/A4lbMvb1xKhMDx96AqAqZpMWuBX1HulhX4g==",
       "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
@@ -762,24 +727,20 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@oxc-project/types": {
+      "version": "0.138.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
+      "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.4.tgz",
+      "integrity": "sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==",
       "cpu": [
         "arm64"
       ],
@@ -788,12 +749,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.4.tgz",
+      "integrity": "sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==",
       "cpu": [
         "arm64"
       ],
@@ -802,12 +766,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.4.tgz",
+      "integrity": "sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==",
       "cpu": [
         "x64"
       ],
@@ -816,26 +783,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.4.tgz",
+      "integrity": "sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==",
       "cpu": [
         "x64"
       ],
@@ -844,46 +800,32 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.4.tgz",
+      "integrity": "sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.4.tgz",
+      "integrity": "sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==",
       "cpu": [
         "arm64"
       ],
@@ -895,12 +837,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.4.tgz",
+      "integrity": "sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==",
       "cpu": [
         "arm64"
       ],
@@ -912,46 +857,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.4.tgz",
+      "integrity": "sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==",
       "cpu": [
         "ppc64"
       ],
@@ -963,63 +877,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.4.tgz",
+      "integrity": "sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==",
       "cpu": [
         "s390x"
       ],
@@ -1031,12 +897,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.4.tgz",
+      "integrity": "sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==",
       "cpu": [
         "x64"
       ],
@@ -1048,12 +917,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.4.tgz",
+      "integrity": "sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==",
       "cpu": [
         "x64"
       ],
@@ -1065,26 +937,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.4.tgz",
+      "integrity": "sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==",
       "cpu": [
         "arm64"
       ],
@@ -1093,12 +954,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.4.tgz",
+      "integrity": "sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.4.tgz",
+      "integrity": "sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==",
       "cpu": [
         "arm64"
       ],
@@ -1107,364 +990,1082 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@solana/buffer-layout": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
-      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "~6.0.3"
-      },
       "engines": {
-        "node": ">=5.10"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@solana/buffer-layout-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout-utils/-/buffer-layout-utils-0.2.0.tgz",
-      "integrity": "sha512-szG4sxgJGktbuZYDg2FfNmkMi0DYQoVjN2h7ta1W1hPrwzarcFLBq9UpX1UjNXsNpT9dn+chgprtWGioUAr4/g==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.4.tgz",
+      "integrity": "sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@solana-program/system": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@solana-program/system/-/system-0.12.2.tgz",
+      "integrity": "sha512-MaBeOxlvTruQhA7UYkOb3hVTEHPPagOtd+PvTm6a8rGgvEAP0kD4BbC37NceOaR4ABNqdaCmD5OMVRKgrE6KAg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@solana/kit": "^6.4.0"
+      }
+    },
+    "node_modules/@solana-program/token": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@solana-program/token/-/token-0.14.0.tgz",
+      "integrity": "sha512-zpLMr6JZndlsQCQvrm0gezfwdr1lmzOGqN6v2WIYXjtDmbF+xg6zh/MAp2UFHRpv3uDmylEdjtQo05pa2OeaYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@solana/web3.js": "^1.32.0",
-        "bigint-buffer": "^1.1.5",
-        "bignumber.js": "^9.0.1"
+        "@solana-program/system": "^0.12.0"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">=24.0.0"
+      },
+      "peerDependencies": {
+        "@solana/kit": "^6.5.0"
+      }
+    },
+    "node_modules/@solana/accounts": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-6.10.0.tgz",
+      "integrity": "sha512-+FxfDOrnifoPlBkF+fr8eeQdgM6xtIgAg9xKMu3WnIz60oZd4Xnry6+ff6t+ePPoZZp397FSg9ZJet68VCWm5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/addresses": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-6.10.0.tgz",
+      "integrity": "sha512-vEoCGBTxG0HCERAn84KXkrJjl+pDaNzOpZ0qbgcPS98fYxP5yzbKB8SNOY2bzrbkRUmmw5Q3hqTRERemUN2Gcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/assertions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-6.10.0.tgz",
+      "integrity": "sha512-lKSAdVo+P/6Lp4vs6shstXmFOpvxrABwn4o1462tb7sKkNapk6o9pPFVPGw4DUgPS3WqWRs1j2tmpuVjhQRntg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-rc.1.tgz",
-      "integrity": "sha512-qxoR7VybNJixV51L0G1RD2boZTcxmwUWnKCaJJExQ5qNKwbpSyDdWfFJfM5JhGyKe9DnPVOZB+JHWXnpbZBqrQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-6.10.0.tgz",
+      "integrity": "sha512-lLVuxod4ChWp9i7OvpgIykYG8Q9OGPVXKnHM9VlzDDLylsx7Y1FoQL00sHa7PqFkJVmkBufaA6dcGbQ7FU+lAQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/options": "2.0.0-rc.1"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/options": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-core": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-rc.1.tgz",
-      "integrity": "sha512-bauxqMfSs8EHD0JKESaNmNuNvkvHSuN3bbWAF5RjOfDu2PugxHrvRebmYauvSumZ3cTfQ4HJJX6PG5rN852qyQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.10.0.tgz",
+      "integrity": "sha512-nfAl9OMGo4HanIMxGsQoVB7BxMoqBCYEUxl8oEAZZ09pDxnaXQZkTRXEwPPccag37XfW1ciPd1vWPKwB2b0HHQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-data-structures": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-rc.1.tgz",
-      "integrity": "sha512-rinCv0RrAVJ9rE/rmaibWJQxMwC5lSaORSZuwjopSUE6T0nb/MVg6Z1siNCXhh/HFTOg0l8bNvZHgBcN/yvXog==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-6.10.0.tgz",
+      "integrity": "sha512-CNasJW3bq5u+632Zt5aJ8rOjAjv2HyenpV8o9kAIqdmV4CBpjCCoBnKn8LkuR/sbeREZxJYfhKTXO/9ruAkw7A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-numbers": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-rc.1.tgz",
-      "integrity": "sha512-J5i5mOkvukXn8E3Z7sGIPxsThRCgSdgTWJDQeZvucQ9PT6Y3HiVXJ0pcWiOWAoQ3RX8e/f4I3IC+wE6pZiJzDQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.10.0.tgz",
+      "integrity": "sha512-CcM+wX4zOiA9zkh8A7t1787A0Ehgmu5+6Z2tKoHew6cNw/dkaUTPa8JnNHbvfsLC8dfHC1BhAEJl86sKmRsfkQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-strings": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-rc.1.tgz",
-      "integrity": "sha512-9/wPhw8TbGRTt6mHC4Zz1RqOnuPTqq1Nb4EyuvpZ39GW6O2t2Q7Q0XxiB3+BdoEjwA2XgPw6e2iRfvYgqty44g==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.10.0.tgz",
+      "integrity": "sha512-zlaqkg7K6F6IN4V/Ec8TWkTn054gxv7ZLagvGkuEyAdPQ6BzzsehOm2TqCuyXgJJTCGPLY1bEk6yH9NxANe0kA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
       },
       "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/errors": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-rc.1.tgz",
-      "integrity": "sha512-ejNvQ2oJ7+bcFAYWj225lyRkHnixuAeb7RQCixm+5mH4n1IA4Qya/9Bmfy5RAAHQzxK43clu3kZmL5eF9VGtYQ==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.10.0.tgz",
+      "integrity": "sha512-KBLAxCtAXr357JNhCyIDQXWbuSj5vN6w+28FSfcYY6OOSiphmXLAV3V58jgV0C6iNbIzFJFi6yatFyDTdeJsNg==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "commander": "^12.1.0"
+        "chalk": "5.6.2",
+        "commander": "15.0.0"
       },
       "bin": {
         "errors": "bin/cli.mjs"
       },
+      "engines": {
+        "node": ">=20.18.0"
+      },
       "peerDependencies": {
-        "typescript": ">=5"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fast-stable-stringify": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-6.10.0.tgz",
+      "integrity": "sha512-iCNed27wk6PKSS3QUtHovRfMWF/jbVWogs2vB4tukKUCsqG4rDfDInIwZ6ur/nY6XTrgi2gMMdZq9GAUlWsbfw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/fixed-points": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/fixed-points/-/fixed-points-6.10.0.tgz",
+      "integrity": "sha512-ZkKL0alXH3L7/wMiVG8YUuG8qBKunlM810+YBD7nUPRhifiGsX1zwADViHLYNqLr/jUk0mTYFUcKznTpB/K+Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/functional": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-6.10.0.tgz",
+      "integrity": "sha512-P8cevu4mAqHTXC37h1TVoOh8zhWB2tlOI/R9vWjYPpcLwcyWf8p2qq4LEGHl5kY+1C+4PNX39HsmCocXOPCDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instruction-plans": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-6.10.0.tgz",
+      "integrity": "sha512-YG7mo4zykzdc6ZTV0BuN6pveK9qeBySzlYYerq578A4eQu3xcypMAYRGAvhMZtWTanjjmD6CKtM0M7kVp0TNxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/instructions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-6.10.0.tgz",
+      "integrity": "sha512-0TToYF+8LXQ3ofPMx+yF6yaM9l4YJvcAPMy0qV5JsrBUFlWXBSANRuudKBQLHMvb+a3OiUTq5X7omuorKMBB3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/keys": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-6.10.0.tgz",
+      "integrity": "sha512-26IRfdm/hTUCmM7MeEeX0ULSbCM6OzkZTkfkrPircqmRM7xyNqP4hq7u0P7wjb9dl7NfgyG6K7cdvUxrj2e3mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/assertions": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/kit": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-6.10.0.tgz",
+      "integrity": "sha512-/WnnQp3uARh2JCFSfAakejTAqwmXVuMVTcRn5r2yDwY2yzZ4R6mt/Cl59VPimVLNSoTyN/KsEwhv9omr3ERazQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/plugin-core": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/program-client-core": "6.10.0",
+        "@solana/programs": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "@solana/sysvars": "6.10.0",
+        "@solana/transaction-confirmation": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/nominal-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-6.10.0.tgz",
+      "integrity": "sha512-9ykyBBvnkInH7fCacjJi7zu2PJyd+OCt+VTjIISv070fHzKIMFqZqJJ/dJ0SRH2aHwfB3n86iVsmtBtuxi4KKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/offchain-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-6.10.0.tgz",
+      "integrity": "sha512-RiEgAueeMkFMC1suOXBIcmCZgtXRxy24yk0DldPB37bB4zwOF1SAaRjNRPjIkGK8RhCYrEpPosnzLyavw9ueRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/options": {
-      "version": "2.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-rc.1.tgz",
-      "integrity": "sha512-mLUcR9mZ3qfHlmMnREdIFPf9dpMc/Bl66tLSOOWxw4ml5xMT2ohFn7WGqoKcu/UHkT9CrC6+amEdqCNvUqI7AA==",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-6.10.0.tgz",
+      "integrity": "sha512-RO9UT3UYD8/Cu2uM6ZXbKvLeMnVD42+g9JRds7Pfs4AhiOyg4R4TJrQUAppTgavPTO3PBRlWtWOC05ZH/yAIbg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.0.0-rc.1",
-        "@solana/codecs-data-structures": "2.0.0-rc.1",
-        "@solana/codecs-numbers": "2.0.0-rc.1",
-        "@solana/codecs-strings": "2.0.0-rc.1",
-        "@solana/errors": "2.0.0-rc.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5"
-      }
-    },
-    "node_modules/@solana/spl-token": {
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.14.tgz",
-      "integrity": "sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@solana/buffer-layout": "^4.0.0",
-        "@solana/buffer-layout-utils": "^0.2.0",
-        "@solana/spl-token-group": "^0.0.7",
-        "@solana/spl-token-metadata": "^0.1.6",
-        "buffer": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.95.5"
-      }
-    },
-    "node_modules/@solana/spl-token-group": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.7.tgz",
-      "integrity": "sha512-V1N/iX7Cr7H0uazWUT2uk27TMqlqedpXHRqqAbVO2gvmJyT0E0ummMEAVQeXZ05ZhQ/xF39DLSdBp90XebWEug==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@solana/codecs": "2.0.0-rc.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.95.3"
-      }
-    },
-    "node_modules/@solana/spl-token-metadata": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz",
-      "integrity": "sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@solana/codecs": "2.0.0-rc.1"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "peerDependencies": {
-        "@solana/web3.js": "^1.95.3"
-      }
-    },
-    "node_modules/@solana/web3.js": {
-      "version": "1.98.4",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
-      "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.25.0",
-        "@noble/curves": "^1.4.2",
-        "@noble/hashes": "^1.4.0",
-        "@solana/buffer-layout": "^4.0.1",
-        "@solana/codecs-numbers": "^2.1.0",
-        "agentkeepalive": "^4.5.0",
-        "bn.js": "^5.2.1",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.1",
-        "node-fetch": "^2.7.0",
-        "rpc-websockets": "^9.0.2",
-        "superstruct": "^2.0.2"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.3.0.tgz",
-      "integrity": "sha512-oG+VZzN6YhBHIoSKgS5ESM9VIGzhWjEHEGNPSibiDTxFhsFWxNaz8LbMDPjBUE69r9wmdGLkrQ+wVPbnJcZPvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@solana/errors": "2.3.0"
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.3.0.tgz",
-      "integrity": "sha512-jFvvwKJKffvG7Iz9dmN51OGB7JBcy2CJ6Xf3NqD/VP90xak66m/Lg48T01u5IQ/hc15mChVHiBm+HHuOFDUrQg==",
+    "node_modules/@solana/plugin-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-6.10.0.tgz",
+      "integrity": "sha512-JE70YTQOfFACVFGvoJon4Scc/eHUWjMu8Ovo35CcV2kHTAHYMCd4UkBd2gmlhK0vRMMomsQi1ZLPlAlTq0OoUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/plugin-interfaces": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-interfaces/-/plugin-interfaces-6.10.0.tgz",
+      "integrity": "sha512-vr0/l9wcM4orwGr8cjkFWaJ9A4HvzuAv00jMFNMg0Spd0GZqnwnpW+D/fXa1lIJnTRaF3EeEjLh4VjKU037T0Q==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "2.3.0",
-        "@solana/errors": "2.3.0"
+        "@solana/addresses": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/signers": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@solana/web3.js/node_modules/@solana/errors": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.3.0.tgz",
-      "integrity": "sha512-66RI9MAbwYV0UtP7kGcTBVLxJgUxoZGm8Fbc0ah+lGiAw17Gugco6+9GrJCV83VyF2mDWyYnYM9qdI3yjgpnaQ==",
+    "node_modules/@solana/program-client-core": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/program-client-core/-/program-client-core-6.10.0.tgz",
+      "integrity": "sha512-4PPbTLdC1ylHIuvhOFDP8RnSkXPCFjNFWGslzc+UFKnoR4ajzBcByX94jmaruDMk5ncxgj7tr9pzJTvfGHIaMA==",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.4.1",
-        "commander": "^14.0.0"
-      },
-      "bin": {
-        "errors": "bin/cli.mjs"
+        "@solana/accounts": "6.10.0",
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instruction-plans": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/plugin-interfaces": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/signers": "6.10.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@solana/web3.js/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
+    "node_modules/@solana/programs": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-6.10.0.tgz",
+      "integrity": "sha512-qn/HeLP5KGUJXVub3fyGe69/rWaLX4jzwm6V/1pNxJDbdF+MBdgn18hP6F+VmhfdNmwK0lue3J/1HQ1UTMuQeQ==",
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "^5.0.1"
+        "@solana/addresses": "6.10.0",
+        "@solana/errors": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@solana/web3.js/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/@solana/web3.js/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+    "node_modules/@solana/promises": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-6.10.0.tgz",
+      "integrity": "sha512-oJSIn+VBBMWDo8oqw7RV3tI6Jih+Ieup6FcQLYLDUriaeo7+8l1Zdezl8zh7SIfeU4lOfAbRg6mR0huaS/Lltg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
+    "node_modules/@solana/rpc": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-6.10.0.tgz",
+      "integrity": "sha512-EwxsqoD+NXV+m+iobnWNtATD93gTgaNsOiQOzYB1/2e+8S6fl6obdNPB55yfXgtl4jt6GV6/ae4xuPhLv76vvg==",
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.8.0"
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-api": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-transport-http": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+    "node_modules/@solana/rpc-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-6.10.0.tgz",
+      "integrity": "sha512-RjPIVsAb/85P1ptoO3WpC0x7QG6gG/e4q/3lo6gbSznUZOcoM+8sSBnCX7BwP1ZkCDS6NK/ClXLnhhhYZx+OGg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-parsed-types": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-parsed-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-6.10.0.tgz",
+      "integrity": "sha512-5275mvSV1mxhwvrMVa+K7BU/nAetpHfcb+8Ql9rtA8RRf6DyiimFQFZUukE4Ez6XJihEpCHNy98yhkgai9wytQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-6.10.0.tgz",
+      "integrity": "sha512-yQdbWw5mZEWrwsunHR9NHkuhMXIB9sPOObwm18D53v5tAJnxTB0IcHvO647XqFDLTK/yQ4AdDtlYD1vsY07AMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-spec-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-6.10.0.tgz",
+      "integrity": "sha512-NDZrKyZrJk4HaMFhTE/lAiMB824cWAodKqDHyKi0UteHU9pyRmil3BN1jt7e+j08mwMWwfklSgyrTaq52g6DIQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-6.10.0.tgz",
+      "integrity": "sha512-6mfuHp/K7unFKCOTCCBC9ziEGnxe2tyJ74EbR51QUnBeCUdYD7Hhdpxic1WRSJ3UeNW/mG4OzFM6z8Wi64Eh9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/fast-stable-stringify": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-subscriptions-api": "6.10.0",
+        "@solana/rpc-subscriptions-channel-websocket": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-api": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-6.10.0.tgz",
+      "integrity": "sha512-CRPQoTtT1cOwOQUsqS7jgo7wYdAj7jB5ab/UmMPWVpecf2FNMhWhgvxP2s82M7VkDGTGl13qaQ0WySmi7Egrlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/rpc-transformers": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-channel-websocket": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-6.10.0.tgz",
+      "integrity": "sha512-KkqP1186HELPlJftA88SNAT2znR8knCVzsUipXVzY4zfW8sN3LOa0ePMzh9VZ/V+J+raTt55laR87ovAO0n+zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/rpc-subscriptions-spec": "6.10.0",
+        "@solana/subscribable": "6.10.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-subscriptions-spec": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-6.10.0.tgz",
+      "integrity": "sha512-nWMwGaG4ulzeX2sskY5TywXF3cwEd8FDmUpLe2JBWxE8XDAOGOKcsYPYFcBgb8ee9KqfPT2PTNdcz9jOhJf34w==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/subscribable": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transformers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-6.10.0.tgz",
+      "integrity": "sha512-2nFUrVTiE720pJOY4XKx3HuYmishw0of/4oScu76YGm6O8wsmvFvPNAkrEinmieWXQkfpBfRvLZmpl8PaAy+ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-transport-http": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-6.10.0.tgz",
+      "integrity": "sha512-JrdNuYi0nBbD3X8JUtgX1dQJwIwz/WJvmigDdELysXfGB2bTJpfjqGDLhCLOz2sRl66FASIEqgG/LVa2C9VXcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-spec": "6.10.0",
+        "@solana/rpc-spec-types": "6.10.0",
+        "undici-types": "^8.4.1"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/rpc-types": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-6.10.0.tgz",
+      "integrity": "sha512-zaSecTfCPvz/vcoAmKD6XoRstGHTr1EKJBD8T9UcpEFFB6CtF6DxerDB+wrzkamuT6msmnR2DWXMrYOGDAsgIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/fixed-points": "6.10.0",
+        "@solana/nominal-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/signers": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-6.10.0.tgz",
+      "integrity": "sha512-+vtCc+mT1FpGxrA5oL2aaMxSHiMJ2hH5PcDIfjo2XJkHz2klZiCZyT5F9+zpltc9vdi1QTElQq59Sfplmtd33A==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/offchain-messages": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/subscribable": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-6.10.0.tgz",
+      "integrity": "sha512-VsR6XMwkiDBkZJUcoGkEOhf397pOV75gKCL9Bx8bpi2T3Bbs0CxUpMn4yaUgAnRba3eXmjbXMNCXjttfa6sKbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/errors": "6.10.0",
+        "@solana/promises": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/sysvars": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-6.10.0.tgz",
+      "integrity": "sha512-cG13p1+onxz+20iWjwWQr1Z1jQwPm0fnjoW75fqZq7p4rVCie3L2sXvaJsYPjWKrUvpOzOIEHnqZGkG05rCpjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/accounts": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-confirmation": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-6.10.0.tgz",
+      "integrity": "sha512-ULvtg65qfenh4T/GYcIlKSUv5EqDcng9UN0dxbHU4kuZdR2e0B8HN2xDC4WhcFQVeFJSbTZmaYFkeTY/Y4gfGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/promises": "6.10.0",
+        "@solana/rpc": "6.10.0",
+        "@solana/rpc-subscriptions": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0",
+        "@solana/transactions": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transaction-messages": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-6.10.0.tgz",
+      "integrity": "sha512-s7v8G3BTxGlKYIj3eWCG0g1296v+1LBt16mVnlRH5FuyaJ5AdhlhtRho5HUDpdwE8EXun+y1c48V6uhcZ8wdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@solana/transactions": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-6.10.0.tgz",
+      "integrity": "sha512-VADSqP9OTYmhrox4pcgDd4+RjVmednXSE0+8Y7SPK4PN1pK5Az2RJ0nSsy0xcTnaOr8mF/crwFktqPrRQwSbQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@solana/addresses": "6.10.0",
+        "@solana/codecs-core": "6.10.0",
+        "@solana/codecs-data-structures": "6.10.0",
+        "@solana/codecs-numbers": "6.10.0",
+        "@solana/codecs-strings": "6.10.0",
+        "@solana/errors": "6.10.0",
+        "@solana/functional": "6.10.0",
+        "@solana/instructions": "6.10.0",
+        "@solana/keys": "6.10.0",
+        "@solana/nominal-types": "6.10.0",
+        "@solana/rpc-types": "6.10.0",
+        "@solana/transaction-messages": "6.10.0"
+      },
+      "engines": {
+        "node": ">=20.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1477,19 +2078,17 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1508,13 +2107,21 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.18.0"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/promise-retry": {
       "version": "1.1.6",
@@ -1533,33 +2140,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.1.tgz",
-      "integrity": "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.63.0.tgz",
+      "integrity": "sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/type-utils": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/type-utils": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1572,7 +2164,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.1",
+        "@typescript-eslint/parser": "^8.63.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1588,16 +2180,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.1.tgz",
-      "integrity": "sha512-sPhE4iHuJDSvoAiec+Ro8JyXw8f0ql13HFR82P99nCm9GwTEKG0KYLvDe6REk8BCXuit6vJAv/Yxg5ABaNS2rA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.63.0.tgz",
+      "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1613,14 +2205,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.1.tgz",
-      "integrity": "sha512-yQ3RgY5RkSBpsNS1Bx/JQEcA24FOSdfGktoyprAr5u18390UQdtVcfnEv4nIrIshNnavlVyZBKxQwT1fIAE6cg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.63.0.tgz",
+      "integrity": "sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.1",
-        "@typescript-eslint/types": "^8.62.1",
+        "@typescript-eslint/tsconfig-utils": "^8.63.0",
+        "@typescript-eslint/types": "^8.63.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1635,14 +2227,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.1.tgz",
-      "integrity": "sha512-r4d249KbQ1SFdpeStvob8Ih6aPPIzfqllPVOtvhve6ZcpuVcYo5/7zUWckKpHE7StASX4kTKZTLf0WQm/wPkcg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.63.0.tgz",
+      "integrity": "sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1"
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1653,9 +2245,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.1.tgz",
-      "integrity": "sha512-xadytJqX9vJVQ2fdQjkcIVigwaOJNWkpjdLt6cEQ+xPnrI1fkp+/jZE/I97k9KUjqtpd25i0HeyZf3T6dutv2g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.63.0.tgz",
+      "integrity": "sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1670,15 +2262,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.1.tgz",
-      "integrity": "sha512-aXM5xlqXiTxPibXB93cLAURfT3rlizf7uMXISCXy66Isr/9hISJx3yDsKl0L7lKa51b8JpFuNKby0/O0pEm9jg==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.63.0.tgz",
+      "integrity": "sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1695,9 +2287,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.1.tgz",
-      "integrity": "sha512-ooCzJFaf+Hg+uG6fA3NRFGuFjlfNlDhBthbv4ZPU/0elCAFUfnyXUvf/WOpHz/jYwSmvU2GkR2LtyUfy1AxZ1Q==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.63.0.tgz",
+      "integrity": "sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1709,16 +2301,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.1.tgz",
-      "integrity": "sha512-xMcW9oP9u7fAMXYs9A65CVmtLQe2r//oXINHfi8HV+oiqhih17sbLdhXr4540YWlgpDKQdY854OL5ZrdCiQsAA==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.63.0.tgz",
+      "integrity": "sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.1",
-        "@typescript-eslint/tsconfig-utils": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/visitor-keys": "8.62.1",
+        "@typescript-eslint/project-service": "8.63.0",
+        "@typescript-eslint/tsconfig-utils": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/visitor-keys": "8.63.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1736,56 +2328,17 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.1.tgz",
-      "integrity": "sha512-sHtbPfuKNZCG+ih8SyjjucqRntSVmp8XgL5u6o9mAhiSn8ds5o/M/XdM0abweme2Tln3szOstOrZ9OXitvPh0g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.63.0.tgz",
+      "integrity": "sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.1",
-        "@typescript-eslint/types": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1"
+        "@typescript-eslint/scope-manager": "8.63.0",
+        "@typescript-eslint/types": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1800,13 +2353,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.1.tgz",
-      "integrity": "sha512-4g3BLxfdTMy8iZG0MaBkadnlRrCJ74cQiFbyEVMrkwIoqdyaXXQM22cotDvrl4x28wgIZ9rEJRoM+mmhSJpJ1g==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.63.0.tgz",
+      "integrity": "sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.1",
+        "@typescript-eslint/types": "8.63.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1817,53 +2370,41 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/@vitest/expect": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
-      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
-      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.7",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -1875,42 +2416,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
-      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
-      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.7",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
-      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -1918,28 +2459,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
-      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
-      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1968,31 +2506,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/acorn-walk": {
-      "version": "8.3.5",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
-      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
-      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "license": "MIT",
-      "dependencies": {
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2010,36 +2523,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2050,83 +2533,14 @@
         "node": ">=12"
       }
     },
-    "node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/base-x": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.1.tgz",
-      "integrity": "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==",
-      "license": "MIT"
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/bigint-buffer": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/bigint-buffer/-/bigint-buffer-1.1.5.tgz",
-      "integrity": "sha512-trfYco6AoZ+rKhKnxA0hgX0HAbVP/s808/EuDSe2JDzUnCp/xAsli35Orvk67UrTEcwuxZqYZDmfA2RXJgxVvA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bindings": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
-      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/bip39": {
@@ -2138,179 +2552,25 @@
         "@noble/hashes": "^1.2.0"
       }
     },
-    "node_modules/bn.js": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.4.tgz",
-      "integrity": "sha512-QL7sb18rJ1PbdsKsqPA0guxL563vIMwRHgzNrW/uzQuRGN1Cjqd/wonUBAVqHox9KwzHA6vCbM0lXx3k4iQMow==",
-      "license": "MIT"
-    },
-    "node_modules/borsh": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "node_modules/borsh/node_modules/base-x": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
-      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/borsh/node_modules/bs58": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^3.0.2"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/bs58": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
-      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "base-x": "^4.0.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/bufferutil": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.1.0.tgz",
-      "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
+        "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": ">=6.14.2"
-      }
-    },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
-      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "get-intrinsic": "^1.3.0",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/call-bound": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
-      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
       "engines": {
         "node": ">=18"
       }
@@ -2327,114 +2587,21 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
-      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=22.12.0"
       }
     },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cross-fetch": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
-      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
-      "license": "MIT",
-      "dependencies": {
-        "node-fetch": "^2.7.0"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2475,16 +2642,6 @@
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "license": "MIT"
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2492,49 +2649,20 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delay": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
-      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
-      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=0.3.1"
+        "node": ">=8"
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -2543,28 +2671,26 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+    "node_modules/ed25519-hd-key": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ed25519-hd-key/-/ed25519-hd-key-2.0.0.tgz",
+      "integrity": "sha512-xWAbQeTHA2DkyirTUYOaOaizcNY/CVNYwprMrnKn0GO1O4LKRXby1nUcj+blr2bT5z44IcyNpA1QPvzLVqHCsA==",
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
+        "@noble/ed25519": "3.1.0",
+        "@noble/hashes": "2.2.0"
       }
     },
-    "node_modules/ed25519-hd-key": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ed25519-hd-key/-/ed25519-hd-key-1.3.0.tgz",
-      "integrity": "sha512-IWwAyiiuJQhgu3L8NaHb68eJxTu2pgCwxIBdgpLJdKpYZM46+AXePSVTr7fkNKaUOfOL4IrjEUaQvyVRIDP7fg==",
+    "node_modules/ed25519-hd-key/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
       "license": "MIT",
-      "dependencies": {
-        "create-hmac": "1.1.7",
-        "tweetnacl": "1.0.3"
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/err-code": {
@@ -2573,57 +2699,12 @@
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
       "license": "MIT"
     },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
-      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "license": "MIT"
-    },
-    "node_modules/es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha512-C+d6UdsYDk0lMebHNR4S2NybQMMngAOnOwYBQjTOiv0MkoJMP0Myw2mgpDLBcpfCmRLxyFqYhS/CfOENq4SJhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es6-promise": "^4.0.3"
-      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -2681,33 +2762,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
-      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.6.0.tgz",
+      "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.5",
-        "@eslint/js": "9.39.4",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -2717,8 +2798,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2726,7 +2806,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -2741,65 +2821,50 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/eslint/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2861,12 +2926,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eventemitter3": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
-      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
-      "license": "MIT"
-    },
     "node_modules/expect-type": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -2875,14 +2934,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
-      "engines": {
-        "node": "> 0.1.90"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2905,19 +2956,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/fast-stable-stringify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-stable-stringify/-/fast-stable-stringify-1.0.0.tgz",
-      "integrity": "sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==",
-      "license": "MIT"
-    },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2949,12 +2987,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/find-up": {
       "version": "5.0.0",
@@ -2994,21 +3026,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/for-each": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
-      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3024,52 +3041,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3083,136 +3054,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hash-base": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^2.3.8",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.0.0"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3223,23 +3064,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -3248,24 +3072,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -3291,110 +3097,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
-      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/isomorphic-ws": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
-      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ws": "*"
-      }
-    },
-    "node_modules/jayson": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/jayson/-/jayson-4.3.0.tgz",
-      "integrity": "sha512-AauzHcUcqs8OBnCHOkJY280VaTiCm57AbuO7lqzcw7JapGj50BisE3xhksye4zlTSR1+1tAz67wLTl8tEH1obQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/connect": "^3.4.33",
-        "@types/node": "^12.12.54",
-        "@types/ws": "^7.4.4",
-        "commander": "^2.20.3",
-        "delay": "^5.0.0",
-        "es6-promisify": "^5.0.0",
-        "eyes": "^0.1.8",
-        "isomorphic-ws": "^4.0.1",
-        "json-stringify-safe": "^5.0.1",
-        "stream-json": "^1.9.1",
-        "uuid": "^8.3.2",
-        "ws": "^7.5.10"
-      },
-      "bin": {
-        "jayson": "bin/jayson.js"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jayson/node_modules/@types/node": {
-      "version": "12.20.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
-      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
-      "license": "MIT"
-    },
-    "node_modules/jayson/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
-    },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -3416,12 +3124,6 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "license": "ISC"
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -3447,6 +3149,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3463,20 +3438,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3487,50 +3448,27 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -3559,36 +3497,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
       "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
-      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -3641,19 +3561,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3681,16 +3588,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3709,15 +3606,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
-      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -3759,12 +3647,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
@@ -3788,37 +3670,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -3828,163 +3679,39 @@
         "node": ">= 4"
       }
     },
-    "node_modules/ripemd160": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.1.2",
-        "inherits": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+    "node_modules/rolldown": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
+      "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.9"
+        "@oxc-project/types": "=0.138.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.1.4",
+        "@rolldown/binding-darwin-arm64": "1.1.4",
+        "@rolldown/binding-darwin-x64": "1.1.4",
+        "@rolldown/binding-freebsd-x64": "1.1.4",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.4",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.4",
+        "@rolldown/binding-linux-arm64-musl": "1.1.4",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.4",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-gnu": "1.1.4",
+        "@rolldown/binding-linux-x64-musl": "1.1.4",
+        "@rolldown/binding-openharmony-arm64": "1.1.4",
+        "@rolldown/binding-wasm32-wasi": "1.1.4",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.4",
+        "@rolldown/binding-win32-x64-msvc": "1.1.4"
       }
-    },
-    "node_modules/rpc-websockets": {
-      "version": "9.3.9",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-9.3.9.tgz",
-      "integrity": "sha512-2iQDaTB4g5fDB2ihrTFSJSibCEuxaRi1q7qTW7ZO9/M5/TC+ToHA4D9/ffNLEbAoHNNrcdeP05oATNk44SKZXA==",
-      "license": "LGPL-3.0-only",
-      "dependencies": {
-        "@swc/helpers": "^0.5.11",
-        "@types/uuid": "^10.0.0",
-        "@types/ws": "^8.2.2",
-        "buffer": "^6.0.3",
-        "eventemitter3": "^5.0.1",
-        "uuid": "^14.0.0",
-        "ws": "^8.5.0"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/kozjak"
-      },
-      "optionalDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^6.0.0"
-      }
-    },
-    "node_modules/rpc-websockets/node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/rpc-websockets/node_modules/utf-8-validate": {
-      "version": "6.0.6",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.6.tgz",
-      "integrity": "sha512-q3l3P9UtEEiAHcsgsqTgf9PPjctrDWoIXW3NpOHFdRDbLvu4DLIcxHangJ4RLrWkBcKjmcs/6NkerI8T/rE4LA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
-    "node_modules/rpc-websockets/node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
-      }
-    },
-    "node_modules/rpc-websockets/node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "7.8.5",
@@ -3997,43 +3724,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.0"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shebang-command": {
@@ -4084,94 +3774,11 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/stream-chain": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/stream-chain/-/stream-chain-2.2.5.tgz",
-      "integrity": "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/stream-json": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/stream-json/-/stream-json-1.9.1.tgz",
-      "integrity": "sha512-uWkjJ+2Nt/LO9Z/JyKZbMusL8Dkh97uUBTv3AJQ74y07lVahLY4eEFsPsE97pxYBwr8nnjMAIch5eqI0gPShyw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "stream-chain": "^2.2.5"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/superstruct": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
-      "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/text-encoding-utf-8": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
-      "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -4181,11 +3788,14 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -4204,61 +3814,15 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/to-buffer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/to-buffer/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
-    },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -4273,55 +3837,32 @@
         "typescript": ">=4.8.4"
       }
     },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+      "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -4342,24 +3883,11 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
-      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4370,16 +3898,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.62.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.1.tgz",
-      "integrity": "sha512-vymnnM5g0AKQDSAyfP12nMIBvgwgA42syg74kkuZ4x1VuTzwQKwc5h9rGxeShCjny5o+zWAb6OEoz7XLgrIkIw==",
+      "version": "8.63.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.63.0.tgz",
+      "integrity": "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.62.1",
-        "@typescript-eslint/parser": "8.62.1",
-        "@typescript-eslint/typescript-estree": "8.62.1",
-        "@typescript-eslint/utils": "8.62.1"
+        "@typescript-eslint/eslint-plugin": "8.63.0",
+        "@typescript-eslint/parser": "8.63.0",
+        "@typescript-eslint/typescript-estree": "8.63.0",
+        "@typescript-eslint/utils": "8.63.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4394,9 +3922,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.7.0.tgz",
+      "integrity": "sha512-gbsS+hAjHg9iV+T8XWdFqnOZEk4f5xrrX3eb9Y1GDe+B5u9H68P6SzYXXUw/rkRvJHRgKIdNfAcrcVj/JvayVA==",
       "license": "MIT"
     },
     "node_modules/uri-js": {
@@ -4409,42 +3937,18 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/vite": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.3.tgz",
+      "integrity": "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.16",
+        "rolldown": "~1.1.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4460,9 +3964,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -4475,13 +3980,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -4507,89 +4015,80 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
-      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.7",
-        "@vitest/mocker": "3.2.7",
-        "@vitest/pretty-format": "^3.2.7",
-        "@vitest/runner": "3.2.7",
-        "@vitest/snapshot": "3.2.7",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.7",
-        "@vitest/ui": "3.2.7",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -4600,23 +4099,10 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -4633,27 +4119,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/which-typed-array": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
-      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.9",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/why-is-node-running": {
@@ -4684,16 +4149,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -4702,16 +4167,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "solana-mmaker",
   "version": "1.0.0",
   "description": "Solana market maker bot implementing a 50/50 portfolio rebalancing strategy via the Jupiter aggregator",
+  "type": "module",
   "scripts": {
     "start": "node dist/main.js",
-    "dev": "ts-node src/main.ts",
+    "dev": "tsx src/main.ts",
     "build": "tsc",
     "test": "vitest run",
     "lint": "eslint src tests"
@@ -19,27 +20,25 @@
   "author": "gianlucamazza",
   "license": "MIT",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
-    "@solana/spl-token": "^0.4.6",
-    "@solana/web3.js": "^1.91.1",
+    "@solana-program/token": "^0.14.0",
+    "@solana/kit": "^6.10.0",
     "bip39": "^3.1.0",
-    "bs58": "^5.0.0",
-    "cross-fetch": "^4.0.0",
     "decimal.js": "^10.4.3",
-    "dotenv": "^16.4.5",
-    "ed25519-hd-key": "^1.3.0",
+    "dotenv": "^17.4.2",
+    "ed25519-hd-key": "^2.0.0",
     "promise-retry": "^2.0.1",
     "tweetnacl": "^1.0.3"
   },
   "devDependencies": {
-    "@types/node": "^20.12.7",
+    "@types/node": "^24.0.0",
     "@types/promise-retry": "^1.1.6",
-    "eslint": "^9.9.0",
-    "ts-node": "^10.9.2",
-    "typescript": "^5.4.5",
-    "typescript-eslint": "^8.0.0",
-    "vitest": "^3.2.6"
+    "eslint": "^10.6.0",
+    "tsx": "^4.23.0",
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.63.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/api/jupiter.ts
+++ b/src/api/jupiter.ts
@@ -1,200 +1,247 @@
-import { Connection, Keypair, VersionedTransaction } from '@solana/web3.js';
-import fetch from 'cross-fetch';
-import promiseRetry from 'promise-retry';
-import { transactionSenderAndConfirmationWaiter } from '../utils/transactionSender';
+import {
+  getBase64Encoder,
+  getBase64EncodedWireTransaction,
+  getSignatureFromTransaction,
+  getTransactionDecoder,
+  signTransaction,
+  type KeyPairSigner,
+} from "@solana/kit";
+import promiseRetry from "promise-retry";
+import { transactionSenderAndConfirmationWaiter } from "../utils/transactionSender.js";
+import type { SolanaRpc } from "./solana.js";
 
-const DEFAULT_BASE_URI = 'https://quote-api.jup.ag/v6';
-
-type FetchResponse = Awaited<ReturnType<typeof fetch>>;
+// Jupiter deprecated the legacy `quote-api.jup.ag/v6` host; the current free
+// endpoint is `lite-api.jup.ag/swap/v1` (paid tier: `api.jup.ag/swap/v1`).
+// The `/quote` and `/swap` paths are unchanged.
+const DEFAULT_BASE_URI = "https://lite-api.jup.ag/swap/v1";
 
 /**
  * fetch with exponential backoff on transient failures (network errors, HTTP
  * 429 and 5xx). The public Jupiter endpoint rate-limits under load, so a single
  * attempt is not reliable. 4xx (other than 429) are returned as-is to the caller.
  */
-async function fetchWithRetry(url: string, init?: Parameters<typeof fetch>[1]): Promise<FetchResponse> {
-    return promiseRetry(
-        async (retry) => {
-            let response: FetchResponse;
-            try {
-                response = await fetch(url, init);
-            } catch (err) {
-                return retry(err);
-            }
-            if (response.status === 429 || response.status >= 500) {
-                return retry(new Error(`Jupiter API transient error (HTTP ${response.status})`));
-            }
-            return response;
-        },
-        { retries: 4, minTimeout: 500, factor: 2 }
-    );
+async function fetchWithRetry(
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  return promiseRetry(
+    async (retry) => {
+      let response: Response;
+      try {
+        response = await fetch(url, init);
+      } catch (err) {
+        return retry(err);
+      }
+      if (response.status === 429 || response.status >= 500) {
+        return retry(
+          new Error(`Jupiter API transient error (HTTP ${response.status})`),
+        );
+      }
+      return response;
+    },
+    { retries: 4, minTimeout: 500, factor: 2 },
+  );
 }
 
 /**
  * Relevant subset of the Jupiter /quote response.
  */
 export interface QuoteResponse {
-    inputMint: string;
-    outputMint: string;
-    inAmount: string;
-    outAmount: string;
-    [key: string]: unknown;
+  inputMint: string;
+  outputMint: string;
+  inAmount: string;
+  outAmount: string;
+  [key: string]: unknown;
 }
 
 /**
  * Relevant subset of the Jupiter /swap response.
  */
 export interface SwapResponse {
-    swapTransaction: string;
-    lastValidBlockHeight?: number;
-    [key: string]: unknown;
+  swapTransaction: string;
+  lastValidBlockHeight?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Optional execution parameters for the Jupiter client.
+ */
+export interface JupiterClientOptions {
+  /** Priority fee in lamports attached to swap transactions. Default: 200000. */
+  priorityFees?: number;
+  /** Skip RPC preflight simulation when sending swaps. Default: false. */
+  skipPreflight?: boolean;
 }
 
 /**
  * Class for interacting with the Jupiter API to perform token swaps on the Solana blockchain.
  */
-/**
- * Optional execution parameters for the Jupiter client.
- */
-export interface JupiterClientOptions {
-    /** Priority fee in lamports attached to swap transactions. Default: 200000. */
-    priorityFees?: number;
-    /** Skip RPC preflight simulation when sending swaps. Default: false. */
-    skipPreflight?: boolean;
-}
-
 export class JupiterClient {
-    baseUri: string;
-    priorityFees: number;
-    skipPreflight: boolean;
+  baseUri: string;
+  priorityFees: number;
+  skipPreflight: boolean;
 
-    /**
-     * Constructs a JupiterClient instance.
-     * @param connection The Solana connection object.
-     * @param userKeypair The user's Solana Keypair.
-     * @param baseUri Optional Jupiter API base URL (defaults to the public v6 endpoint).
-     * @param options Optional execution parameters (priority fees, preflight).
-     */
-    constructor(private connection: Connection, private userKeypair: Keypair, baseUri?: string, options: JupiterClientOptions = {}) {
-        this.baseUri = baseUri || DEFAULT_BASE_URI;
-        this.priorityFees = options.priorityFees ?? 200000;
-        this.skipPreflight = options.skipPreflight ?? false;
+  /**
+   * Constructs a JupiterClient instance.
+   * @param rpc The Solana RPC client.
+   * @param signer The user's Solana signer.
+   * @param baseUri Optional Jupiter API base URL (defaults to the public v6 endpoint).
+   * @param options Optional execution parameters (priority fees, preflight).
+   */
+  constructor(
+    private rpc: SolanaRpc,
+    private signer: KeyPairSigner,
+    baseUri?: string,
+    options: JupiterClientOptions = {},
+  ) {
+    this.baseUri = baseUri || DEFAULT_BASE_URI;
+    this.priorityFees = options.priorityFees ?? 200000;
+    this.skipPreflight = options.skipPreflight ?? false;
+  }
+
+  /**
+   * Get the Solana RPC client.
+   * @returns The Solana RPC client.
+   */
+  public getRpc(): SolanaRpc {
+    return this.rpc;
+  }
+
+  /**
+   * Get the user signer.
+   * @returns The user signer.
+   */
+  getSigner(): KeyPairSigner {
+    return this.signer;
+  }
+
+  /**
+   * Retrieves a swap quote from the Jupiter API.
+   * @param inputMint The address of the input token mint.
+   * @param outputMint The address of the output token mint.
+   * @param amount The amount of input tokens to swap, in minor units.
+   * @param slippageBps The maximum slippage allowed, in basis points.
+   * @returns A promise that resolves to the swap quote.
+   */
+  async getQuote(
+    inputMint: string,
+    outputMint: string,
+    amount: string,
+    slippageBps: number,
+  ): Promise<QuoteResponse> {
+    console.log(`Getting quote for ${amount} ${inputMint} -> ${outputMint}`);
+    const response = await fetchWithRetry(
+      `${this.baseUri}/quote?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amount}&slippageBps=${slippageBps}`,
+    );
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Failed to get quote (HTTP ${response.status}): ${errorBody}`,
+      );
+    }
+    return (await response.json()) as QuoteResponse;
+  }
+
+  /**
+   * Retrieves a swap transaction from the Jupiter API.
+   * @param quoteResponse The response from the getQuote method.
+   * @param wrapAndUnwrapSol Whether to wrap and unwrap SOL if necessary.
+   * @param priorityFees An optional priority fee amount in lamports.
+   * @param feeAccount An optional fee account address.
+   * @returns A promise that resolves to the swap response (serialized transaction plus expiry metadata).
+   */
+  async getSwapTransaction(
+    quoteResponse: QuoteResponse,
+    wrapAndUnwrapSol: boolean = true,
+    priorityFees: number = this.priorityFees,
+    feeAccount?: string,
+  ): Promise<SwapResponse> {
+    const body = {
+      quoteResponse,
+      userPublicKey: this.signer.address,
+      wrapAndUnwrapSol,
+      ...(feeAccount && { feeAccount }),
+      prioritizationFeeLamports: priorityFees,
+      dynamicComputeUnitLimit: true,
+    };
+
+    const response = await fetchWithRetry(`${this.baseUri}/swap`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      throw new Error(
+        `Failed to get swap transaction (HTTP ${response.status}): ${errorBody}`,
+      );
     }
 
-    /**
-     * Get the Solana connection.
-     * @returns The Solana connection.
-     */
-    public getConnection(): Connection {
-        return this.connection;
+    const swapResponse = (await response.json()) as SwapResponse;
+    if (!swapResponse.swapTransaction) {
+      throw new Error(
+        "Jupiter /swap response did not contain a swapTransaction",
+      );
     }
+    return swapResponse;
+  }
 
-    /**
-     * Get the user keypair.
-     * @returns The user keypair.
-     */
-    getUserKeypair(): Keypair {
-        return this.userKeypair;
-    }
+  /**
+   * Executes a swap transaction on the Solana blockchain.
+   * @param swapResponse The swap response obtained from getSwapTransaction.
+   * @returns A promise that resolves to a boolean indicating whether the transaction was successfully confirmed.
+   */
+  async executeSwap(swapResponse: SwapResponse): Promise<boolean> {
+    try {
+      // Jupiter returns a fully-built, unsigned transaction as base64. Decode it,
+      // sign it with the user's key, and re-encode it to the base64 wire format.
+      const transactionBytes = getBase64Encoder().encode(
+        swapResponse.swapTransaction,
+      );
+      const decodedTransaction =
+        getTransactionDecoder().decode(transactionBytes);
+      const signedTransaction = await signTransaction(
+        [this.signer.keyPair],
+        decodedTransaction,
+      );
+      const signature = getSignatureFromTransaction(signedTransaction);
+      const base64Transaction =
+        getBase64EncodedWireTransaction(signedTransaction);
 
-    /**
-     * Retrieves a swap quote from the Jupiter API.
-     * @param inputMint The address of the input token mint.
-     * @param outputMint The address of the output token mint.
-     * @param amount The amount of input tokens to swap, in minor units.
-     * @param slippageBps The maximum slippage allowed, in basis points.
-     * @returns A promise that resolves to the swap quote.
-     */
-    async getQuote(inputMint: string, outputMint: string, amount: string, slippageBps: number): Promise<QuoteResponse> {
-        console.log(`Getting quote for ${amount} ${inputMint} -> ${outputMint}`);
-        const response = await fetchWithRetry(
-            `${this.baseUri}/quote?inputMint=${inputMint}&outputMint=${outputMint}&amount=${amount}&slippageBps=${slippageBps}`
+      // Track expiry against the blockhash embedded in the Jupiter transaction;
+      // a freshly fetched blockhash would make expiry detection unreliable.
+      const lastValidBlockHeight =
+        swapResponse.lastValidBlockHeight !== undefined
+          ? BigInt(swapResponse.lastValidBlockHeight)
+          : (await this.rpc.getLatestBlockhash().send()).value
+              .lastValidBlockHeight;
+
+      const confirmation = await transactionSenderAndConfirmationWaiter({
+        rpc: this.rpc,
+        base64Transaction,
+        signature,
+        lastValidBlockHeight,
+        skipPreflight: this.skipPreflight,
+      });
+
+      if (!confirmation) {
+        console.error("Swap transaction expired or failed.");
+        return false;
+      }
+      if (confirmation.meta && confirmation.meta.err) {
+        console.error(
+          "Swap transaction failed with error:",
+          confirmation.meta.err,
         );
-        if (!response.ok) {
-            const errorBody = await response.text();
-            throw new Error(`Failed to get quote (HTTP ${response.status}): ${errorBody}`);
-        }
-        return await response.json() as QuoteResponse;
+        return false;
+      }
+
+      console.log("Swap transaction confirmed");
+      return true;
+    } catch (err) {
+      console.error("Failed to send swap transaction:", err);
+      return false;
     }
-
-    /**
-     * Retrieves a swap transaction from the Jupiter API.
-     * @param quoteResponse The response from the getQuote method.
-     * @param wrapAndUnwrapSol Whether to wrap and unwrap SOL if necessary.
-     * @param priorityFees An optional priority fee amount in lamports.
-     * @param feeAccount An optional fee account address.
-     * @returns A promise that resolves to the swap response (serialized transaction plus expiry metadata).
-     */
-    async getSwapTransaction(quoteResponse: QuoteResponse, wrapAndUnwrapSol: boolean = true, priorityFees: number = this.priorityFees, feeAccount?: string): Promise<SwapResponse> {
-        const body = {
-            quoteResponse,
-            userPublicKey: this.userKeypair.publicKey.toString(),
-            wrapAndUnwrapSol,
-            ...(feeAccount && { feeAccount }),
-            prioritizationFeeLamports: priorityFees,
-            dynamicComputeUnitLimit: true,
-        };
-
-        const response = await fetchWithRetry(`${this.baseUri}/swap`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(body)
-        });
-
-        if (!response.ok) {
-            const errorBody = await response.text();
-            throw new Error(`Failed to get swap transaction (HTTP ${response.status}): ${errorBody}`);
-        }
-
-        const swapResponse = await response.json() as SwapResponse;
-        if (!swapResponse.swapTransaction) {
-            throw new Error('Jupiter /swap response did not contain a swapTransaction');
-        }
-        return swapResponse;
-    }
-
-    /**
-     * Executes a swap transaction on the Solana blockchain.
-     * @param swapResponse The swap response obtained from getSwapTransaction.
-     * @returns A promise that resolves to a boolean indicating whether the transaction was successfully confirmed.
-     */
-    async executeSwap(swapResponse: SwapResponse): Promise<boolean> {
-        try {
-            const swapTransactionBuf = Buffer.from(swapResponse.swapTransaction, 'base64');
-            const transaction = VersionedTransaction.deserialize(swapTransactionBuf);
-            transaction.sign([this.userKeypair]);
-
-            const connection = this.getConnection();
-
-            // Track expiry against the blockhash embedded in the Jupiter transaction;
-            // a freshly fetched blockhash would make expiry detection unreliable.
-            const blockhash = transaction.message.recentBlockhash;
-            const lastValidBlockHeight = swapResponse.lastValidBlockHeight
-                ?? (await connection.getLatestBlockhash()).lastValidBlockHeight;
-
-            const serializedTransaction = Buffer.from(transaction.serialize());
-
-            const confirmation = await transactionSenderAndConfirmationWaiter({
-                connection,
-                serializedTransaction,
-                blockhashWithExpiryBlockHeight: { blockhash, lastValidBlockHeight },
-                skipPreflight: this.skipPreflight,
-            });
-
-            if (!confirmation) {
-                console.error('Swap transaction expired or failed.');
-                return false;
-            }
-            if (confirmation.meta && confirmation.meta.err) {
-                console.error('Swap transaction failed with error:', confirmation.meta.err);
-                return false;
-            }
-
-            console.log('Swap transaction confirmed');
-            return true;
-        } catch (err) {
-            console.error('Failed to send swap transaction:', err);
-            return false;
-        }
-    }
+  }
 }

--- a/src/api/solana.ts
+++ b/src/api/solana.ts
@@ -1,29 +1,42 @@
-import { Connection, PublicKey } from '@solana/web3.js';
+import { address, createSolanaRpc } from "@solana/kit";
 
 /**
- * Setup connection to Solana RPC endpoint
- * @param {string} endpoint - RPC endpoint
- * @returns {Connection} - Connection object
+ * A Solana JSON-RPC client, as produced by {@link createSolanaRpc}.
+ * The @solana/kit RPC is a functional client: each method returns a request
+ * object whose `.send()` performs the call.
  */
-export function setupSolanaConnection(endpoint: string): Connection {
-    return new Connection(endpoint, 'confirmed');
+export type SolanaRpc = ReturnType<typeof createSolanaRpc>;
+
+/**
+ * Create an RPC client for a Solana endpoint.
+ * @param endpoint HTTP RPC endpoint URL.
+ * @returns An RPC client.
+ */
+export function setupSolanaConnection(endpoint: string): SolanaRpc {
+  return createSolanaRpc(endpoint);
 }
 
 /**
  * Read the decimals of an SPL token mint from the chain.
- * @param connection Solana connection object.
+ * @param rpc Solana RPC client.
  * @param mintAddress Token mint address.
  * @returns The mint's decimals.
  */
-export async function getMintDecimals(connection: Connection, mintAddress: string): Promise<number> {
-    const info = await connection.getParsedAccountInfo(new PublicKey(mintAddress));
-    const data = info.value?.data;
-    if (!data || typeof data !== 'object' || !('parsed' in data)) {
-        throw new Error(`Unable to read mint account ${mintAddress}`);
-    }
-    const decimals = data.parsed?.info?.decimals;
-    if (typeof decimals !== 'number') {
-        throw new Error(`Mint account ${mintAddress} has no decimals field`);
-    }
-    return decimals;
+export async function getMintDecimals(
+  rpc: SolanaRpc,
+  mintAddress: string,
+): Promise<number> {
+  const info = await rpc
+    .getAccountInfo(address(mintAddress), { encoding: "jsonParsed" })
+    .send();
+  const data = info.value?.data;
+  if (!data || typeof data !== "object" || !("parsed" in data)) {
+    throw new Error(`Unable to read mint account ${mintAddress}`);
+  }
+  const decimals = (data as { parsed?: { info?: { decimals?: unknown } } })
+    .parsed?.info?.decimals;
+  if (typeof decimals !== "number") {
+    throw new Error(`Mint account ${mintAddress} has no decimals field`);
+  }
+  return decimals;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,73 +1,82 @@
-import dotenv from 'dotenv';
-import { JupiterClient } from './api/jupiter';
-import { setupSolanaConnection } from './api/solana';
-import { MarketMaker, MarketMakerConfig } from './strategies/basicMM';
-import { loadKeypair } from './wallet';
+import dotenv from "dotenv";
+import { JupiterClient } from "./api/jupiter.js";
+import { setupSolanaConnection } from "./api/solana.js";
+import { MarketMaker, MarketMakerConfig } from "./strategies/basicMM.js";
+import { loadKeypair } from "./wallet.js";
 
 /**
  * Parse an optional numeric environment variable, throwing on malformed values.
  */
 function parseNumberEnv(name: string): number | undefined {
-    const raw = process.env[name];
-    if (raw === undefined || raw === '') return undefined;
-    const value = Number(raw);
-    if (Number.isNaN(value)) {
-        throw new Error(`${name} must be a number, got "${raw}"`);
-    }
-    return value;
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return undefined;
+  const value = Number(raw);
+  if (Number.isNaN(value)) {
+    throw new Error(`${name} must be a number, got "${raw}"`);
+  }
+  return value;
 }
 
 async function main() {
-    dotenv.config();
+  dotenv.config();
 
-    if (!process.env.SOLANA_RPC_ENDPOINT) {
-        throw new Error('SOLANA_RPC_ENDPOINT is not set');
-    }
+  if (!process.env.SOLANA_RPC_ENDPOINT) {
+    throw new Error("SOLANA_RPC_ENDPOINT is not set");
+  }
 
-    if (!process.env.USER_KEYPAIR && !process.env.SOLANA_MNEMONIC) {
-        console.warn('Neither USER_KEYPAIR nor SOLANA_MNEMONIC is set; falling back to ~/.config/solana/id.json');
-    }
+  if (!process.env.USER_KEYPAIR && !process.env.SOLANA_MNEMONIC) {
+    console.warn(
+      "Neither USER_KEYPAIR nor SOLANA_MNEMONIC is set; falling back to ~/.config/solana/id.json",
+    );
+  }
 
-    if (!process.env.ENABLE_TRADING) {
-        console.warn('ENABLE_TRADING is not set. Defaulting to false');
-    }
+  if (!process.env.ENABLE_TRADING) {
+    console.warn("ENABLE_TRADING is not set. Defaulting to false");
+  }
 
-    const connection = setupSolanaConnection(process.env.SOLANA_RPC_ENDPOINT);
-    console.log(`Network: ${connection.rpcEndpoint}`);
-    const userKeypair = loadKeypair();
-    console.log('MarketMaker PubKey:', userKeypair.publicKey.toBase58());
+  const rpc = setupSolanaConnection(process.env.SOLANA_RPC_ENDPOINT);
+  console.log(`Network: ${process.env.SOLANA_RPC_ENDPOINT}`);
+  const signer = await loadKeypair();
+  console.log("MarketMaker PubKey:", signer.address);
 
-    const priorityFees = parseNumberEnv('MM_PRIORITY_FEE_LAMPORTS') ?? 200000;
-    if (!Number.isInteger(priorityFees) || priorityFees < 0) {
-        throw new Error(`MM_PRIORITY_FEE_LAMPORTS must be a non-negative integer, got ${priorityFees}`);
-    }
-    const jupiterClient = new JupiterClient(connection, userKeypair, process.env.JUPITER_API_BASE_URL, {
-        priorityFees,
-        skipPreflight: process.env.MM_SKIP_PREFLIGHT === 'true',
+  const priorityFees = parseNumberEnv("MM_PRIORITY_FEE_LAMPORTS") ?? 200000;
+  if (!Number.isInteger(priorityFees) || priorityFees < 0) {
+    throw new Error(
+      `MM_PRIORITY_FEE_LAMPORTS must be a non-negative integer, got ${priorityFees}`,
+    );
+  }
+  const jupiterClient = new JupiterClient(
+    rpc,
+    signer,
+    process.env.JUPITER_API_BASE_URL,
+    {
+      priorityFees,
+      skipPreflight: process.env.MM_SKIP_PREFLIGHT === "true",
+    },
+  );
+
+  const enabled = process.env.ENABLE_TRADING === "true";
+  const config: MarketMakerConfig = {
+    waitTime: parseNumberEnv("MM_WAIT_TIME_MS"),
+    slippageBps: parseNumberEnv("MM_SLIPPAGE_BPS"),
+    priceTolerance: parseNumberEnv("MM_PRICE_TOLERANCE"),
+    rebalancePercentage: parseNumberEnv("MM_REBALANCE_PERCENTAGE"),
+    minimumTradeValueUsd: parseNumberEnv("MM_MINIMUM_TRADE_VALUE_USD"),
+  };
+  const marketMaker = new MarketMaker(config);
+
+  // Graceful shutdown: stop the run loop after the current cycle.
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      console.log(`Received ${signal}, shutting down...`);
+      marketMaker.stop();
     });
+  }
 
-    const enabled = process.env.ENABLE_TRADING === 'true';
-    const config: MarketMakerConfig = {
-        waitTime: parseNumberEnv('MM_WAIT_TIME_MS'),
-        slippageBps: parseNumberEnv('MM_SLIPPAGE_BPS'),
-        priceTolerance: parseNumberEnv('MM_PRICE_TOLERANCE'),
-        rebalancePercentage: parseNumberEnv('MM_REBALANCE_PERCENTAGE'),
-        minimumTradeValueUsd: parseNumberEnv('MM_MINIMUM_TRADE_VALUE_USD'),
-    };
-    const marketMaker = new MarketMaker(config);
-
-    // Graceful shutdown: stop the run loop after the current cycle.
-    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-        process.once(signal, () => {
-            console.log(`Received ${signal}, shutting down...`);
-            marketMaker.stop();
-        });
-    }
-
-    await marketMaker.runMM(jupiterClient, enabled);
+  await marketMaker.runMM(jupiterClient, enabled);
 }
 
 main().catch((err) => {
-    console.error(err);
-    process.exit(1);
+  console.error(err);
+  process.exit(1);
 });

--- a/src/strategies/basicMM.ts
+++ b/src/strategies/basicMM.ts
@@ -1,11 +1,15 @@
-import { TOKEN_PROGRAM_ID } from '@solana/spl-token';
-import { Connection, PublicKey } from '@solana/web3.js';
-import Decimal from 'decimal.js';
-import { JupiterClient, SwapResponse } from '../api/jupiter';
-import { getMintDecimals } from '../api/solana';
-import { SOL_MINT_ADDRESS, MBC_MINT_ADDRESS, USDC_MINT_ADDRESS } from '../constants/constants';
-import { fromNumberToLamports } from '../utils/convert';
-import { sleep } from '../utils/sleep';
+import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
+import { address, type Address } from "@solana/kit";
+import { Decimal } from "decimal.js";
+import { JupiterClient, SwapResponse } from "../api/jupiter.js";
+import { getMintDecimals, type SolanaRpc } from "../api/solana.js";
+import {
+  SOL_MINT_ADDRESS,
+  MBC_MINT_ADDRESS,
+  USDC_MINT_ADDRESS,
+} from "../constants/constants.js";
+import { fromNumberToLamports } from "../utils/convert.js";
+import { sleep } from "../utils/sleep.js";
 
 /**
  * Slippage used only for *pricing* quotes. Kept at 0 so the portfolio valuation
@@ -14,36 +18,38 @@ import { sleep } from '../utils/sleep';
 const PRICE_QUOTE_SLIPPAGE_BPS = 0;
 
 export interface Token {
-    address: string;
-    symbol: string;
-    decimals: number;
+  address: string;
+  symbol: string;
+  decimals: number;
 }
 
 export interface TradePair {
-    token0: Token;
-    token1: Token;
+  token0: Token;
+  token1: Token;
 }
 
 export interface MarketMakerConfig {
-    /** Milliseconds between rebalance checks. Default: 60000 (1 minute). */
-    waitTime?: number;
-    /** Maximum slippage in basis points. Default: 50 (0.5%). */
-    slippageBps?: number;
-    /** Portfolio imbalance, as a fraction of total value, required to trigger a rebalance. Default: 0.02 (2%). */
-    priceTolerance?: number;
-    /** Target share of total value held in token0. Default: 0.5 (50/50). */
-    rebalancePercentage?: number;
-    /** Minimum trade value in USD for a rebalance to be worth executing. Default: 1. */
-    minimumTradeValueUsd?: number;
+  /** Milliseconds between rebalance checks. Default: 60000 (1 minute). */
+  waitTime?: number;
+  /** Maximum slippage in basis points. Default: 50 (0.5%). */
+  slippageBps?: number;
+  /** Portfolio imbalance, as a fraction of total value, required to trigger a rebalance. Default: 0.02 (2%). */
+  priceTolerance?: number;
+  /** Target share of total value held in token0. Default: 0.5 (50/50). */
+  rebalancePercentage?: number;
+  /** Minimum trade value in USD for a rebalance to be worth executing. Default: 1. */
+  minimumTradeValueUsd?: number;
 }
 
 /**
  * Throw if `value` is outside `(min, max)` (exclusive) — used for fraction parameters.
  */
 function assertFraction(name: string, value: number): void {
-    if (!Number.isFinite(value) || value <= 0 || value >= 1) {
-        throw new Error(`${name} must be a number in the open interval (0, 1), got ${value}`);
-    }
+  if (!Number.isFinite(value) || value <= 0 || value >= 1) {
+    throw new Error(
+      `${name} must be a number in the open interval (0, 1), got ${value}`,
+    );
+  }
 }
 
 /**
@@ -51,278 +57,398 @@ function assertFraction(name: string, value: number): void {
  * bot trade unsafely (e.g. a rebalance target above 100% or a negative slippage).
  */
 function validateStrategyConfig(params: {
-    waitTime: number;
-    slippageBps: number;
-    priceTolerance: number;
-    rebalancePercentage: number;
-    minimumTradeValueUsd: Decimal;
+  waitTime: number;
+  slippageBps: number;
+  priceTolerance: number;
+  rebalancePercentage: number;
+  minimumTradeValueUsd: Decimal;
 }): void {
-    if (!Number.isInteger(params.slippageBps) || params.slippageBps < 1 || params.slippageBps > 1000) {
-        throw new Error(`slippageBps must be an integer in [1, 1000] bps, got ${params.slippageBps}`);
-    }
-    assertFraction('rebalancePercentage', params.rebalancePercentage);
-    assertFraction('priceTolerance', params.priceTolerance);
-    if (!params.minimumTradeValueUsd.isFinite() || params.minimumTradeValueUsd.lte(0)) {
-        throw new Error(`minimumTradeValueUsd must be > 0, got ${params.minimumTradeValueUsd.toString()}`);
-    }
-    if (!Number.isFinite(params.waitTime) || params.waitTime < 1000) {
-        throw new Error(`waitTime must be >= 1000 ms, got ${params.waitTime}`);
-    }
+  if (
+    !Number.isInteger(params.slippageBps) ||
+    params.slippageBps < 1 ||
+    params.slippageBps > 1000
+  ) {
+    throw new Error(
+      `slippageBps must be an integer in [1, 1000] bps, got ${params.slippageBps}`,
+    );
+  }
+  assertFraction("rebalancePercentage", params.rebalancePercentage);
+  assertFraction("priceTolerance", params.priceTolerance);
+  if (
+    !params.minimumTradeValueUsd.isFinite() ||
+    params.minimumTradeValueUsd.lte(0)
+  ) {
+    throw new Error(
+      `minimumTradeValueUsd must be > 0, got ${params.minimumTradeValueUsd.toString()}`,
+    );
+  }
+  if (!Number.isFinite(params.waitTime) || params.waitTime < 1000) {
+    throw new Error(`waitTime must be >= 1000 ms, got ${params.waitTime}`);
+  }
 }
 
 /**
  * Class for market making basic strategy
  */
 export class MarketMaker {
-    mbcToken: Token;
-    solToken: Token;
-    usdcToken: Token;
-    waitTime: number;
-    slippageBps: number;
-    priceTolerance: number;
-    rebalancePercentage: number;
-    minimumTradeValueUsd: Decimal;
-    private running: boolean = true;
+  mbcToken: Token;
+  solToken: Token;
+  usdcToken: Token;
+  waitTime: number;
+  slippageBps: number;
+  priceTolerance: number;
+  rebalancePercentage: number;
+  minimumTradeValueUsd: Decimal;
+  private running: boolean = true;
 
-    /**
-     * Initializes a new instance of the MarketMaker class.
-     * @param config Optional overrides for the strategy parameters.
-     */
-    constructor(config: MarketMakerConfig = {}) {
-        this.mbcToken = { address: MBC_MINT_ADDRESS, symbol: 'MBC', decimals: 9 };
-        this.solToken = { address: SOL_MINT_ADDRESS, symbol: 'SOL', decimals: 9 };
-        this.usdcToken = { address: USDC_MINT_ADDRESS, symbol: 'USDC', decimals: 6 };
-        this.waitTime = config.waitTime ?? 60000; // 1 minute
-        this.slippageBps = config.slippageBps ?? 50; // 0.5%
-        this.priceTolerance = config.priceTolerance ?? 0.02; // 2%
-        this.rebalancePercentage = config.rebalancePercentage ?? 0.5; // 50%
-        this.minimumTradeValueUsd = new Decimal(config.minimumTradeValueUsd ?? 1); // $1
+  /**
+   * Initializes a new instance of the MarketMaker class.
+   * @param config Optional overrides for the strategy parameters.
+   */
+  constructor(config: MarketMakerConfig = {}) {
+    this.mbcToken = { address: MBC_MINT_ADDRESS, symbol: "MBC", decimals: 9 };
+    this.solToken = { address: SOL_MINT_ADDRESS, symbol: "SOL", decimals: 9 };
+    this.usdcToken = {
+      address: USDC_MINT_ADDRESS,
+      symbol: "USDC",
+      decimals: 6,
+    };
+    this.waitTime = config.waitTime ?? 60000; // 1 minute
+    this.slippageBps = config.slippageBps ?? 50; // 0.5%
+    this.priceTolerance = config.priceTolerance ?? 0.02; // 2%
+    this.rebalancePercentage = config.rebalancePercentage ?? 0.5; // 50%
+    this.minimumTradeValueUsd = new Decimal(config.minimumTradeValueUsd ?? 1); // $1
 
-        validateStrategyConfig(this);
+    validateStrategyConfig(this);
+  }
+
+  /**
+   * Run market making strategy
+   * @param {JupiterClient} jupiterClient - JupiterClient object
+   * @param {boolean} enableTrading - Enable trading
+   * @returns {Promise<void>} - Promise object
+   */
+  async runMM(
+    jupiterClient: JupiterClient,
+    enableTrading: boolean = false,
+  ): Promise<void> {
+    const tradePairs: TradePair[] = [
+      { token0: this.solToken, token1: this.mbcToken },
+    ];
+    await this.syncTokenDecimals(jupiterClient.getRpc());
+
+    while (this.running) {
+      for (const pair of tradePairs) {
+        if (!this.running) break;
+        try {
+          await this.evaluateAndExecuteTrade(
+            jupiterClient,
+            pair,
+            enableTrading,
+          );
+        } catch (err) {
+          // A transient RPC/API failure must not kill the bot; retry on the next cycle.
+          // Missing-price/route conditions are handled explicitly in
+          // determineTradeNecessity, so anything reaching here is an unexpected error.
+          console.error(
+            `Rebalance iteration for ${pair.token0.symbol}/${pair.token1.symbol} failed unexpectedly:`,
+            err,
+          );
+        }
+      }
+
+      if (!this.running) break;
+      console.log(`Waiting for ${this.waitTime / 1000} seconds...`);
+      await sleep(this.waitTime);
     }
 
-    /**
-     * Run market making strategy
-     * @param {JupiterClient} jupiterClient - JupiterClient object
-     * @param {boolean} enableTrading - Enable trading
-     * @returns {Promise<void>} - Promise object
-     */
-    async runMM(jupiterClient: JupiterClient, enableTrading: boolean = false): Promise<void> {
-        const tradePairs: TradePair[] = [{ token0: this.solToken, token1: this.mbcToken }];
-        await this.syncTokenDecimals(jupiterClient.getConnection());
+    console.log("Market maker stopped.");
+  }
 
-        while (this.running) {
-            for (const pair of tradePairs) {
-                if (!this.running) break;
-                try {
-                    await this.evaluateAndExecuteTrade(jupiterClient, pair, enableTrading);
-                } catch (err) {
-                    // A transient RPC/API failure must not kill the bot; retry on the next cycle.
-                    // Missing-price/route conditions are handled explicitly in
-                    // determineTradeNecessity, so anything reaching here is an unexpected error.
-                    console.error(`Rebalance iteration for ${pair.token0.symbol}/${pair.token1.symbol} failed unexpectedly:`, err);
-                }
-            }
+  /**
+   * Request a graceful shutdown: the run loop exits after the current cycle.
+   */
+  stop(): void {
+    if (this.running) {
+      console.log("Shutdown requested; finishing the current cycle...");
+      this.running = false;
+    }
+  }
 
-            if (!this.running) break;
-            console.log(`Waiting for ${this.waitTime / 1000} seconds...`);
-            await sleep(this.waitTime);
+  /**
+   * Read SPL token decimals from the chain so the hardcoded defaults cannot drift
+   * from the actual mint configuration.
+   * @param rpc Solana RPC client.
+   */
+  async syncTokenDecimals(rpc: SolanaRpc): Promise<void> {
+    for (const token of [this.mbcToken, this.usdcToken]) {
+      try {
+        const decimals = await getMintDecimals(rpc, token.address);
+        if (decimals !== token.decimals) {
+          console.warn(
+            `Correcting ${token.symbol} decimals from ${token.decimals} to on-chain value ${decimals}`,
+          );
+          token.decimals = decimals;
         }
+      } catch (err) {
+        console.warn(
+          `Could not verify ${token.symbol} decimals on-chain, keeping ${token.decimals}:`,
+          err,
+        );
+      }
+    }
+  }
 
-        console.log('Market maker stopped.');
+  /**
+   * Evaluate and execute trade
+   * @param {JupiterClient} jupiterClient - JupiterClient object
+   * @param {TradePair} pair - Pair object
+   * @param {boolean} enableTrading - Enable trading
+   * @returns {Promise<void>} - Promise object
+   */
+  async evaluateAndExecuteTrade(
+    jupiterClient: JupiterClient,
+    pair: TradePair,
+    enableTrading: boolean,
+  ): Promise<void> {
+    const token0Balance = await this.fetchTokenBalance(
+      jupiterClient,
+      pair.token0,
+    );
+    const token1Balance = await this.fetchTokenBalance(
+      jupiterClient,
+      pair.token1,
+    );
+
+    console.log(
+      `Token0 balance (in ${pair.token0.symbol}): ${token0Balance.toString()}`,
+    );
+    console.log(
+      `Token1 balance (in ${pair.token1.symbol}): ${token1Balance.toString()}`,
+    );
+
+    const { tradeNeeded, solAmountToTrade, mbcAmountToTrade } =
+      await this.determineTradeNecessity(
+        jupiterClient,
+        pair,
+        token0Balance,
+        token1Balance,
+      );
+
+    if (!tradeNeeded) {
+      console.log("No trade needed");
+      return;
     }
 
-    /**
-     * Request a graceful shutdown: the run loop exits after the current cycle.
-     */
-    stop(): void {
-        if (this.running) {
-            console.log('Shutdown requested; finishing the current cycle...');
-            this.running = false;
-        }
+    console.log("Trade needed");
+    if (solAmountToTrade.gt(0)) {
+      await this.executeTrade(
+        jupiterClient,
+        pair.token0,
+        pair.token1,
+        solAmountToTrade,
+        enableTrading,
+      );
+    } else if (mbcAmountToTrade.gt(0)) {
+      await this.executeTrade(
+        jupiterClient,
+        pair.token1,
+        pair.token0,
+        mbcAmountToTrade,
+        enableTrading,
+      );
+    }
+  }
+
+  /**
+   * Quote and execute a single swap, surfacing failures instead of ignoring them.
+   */
+  private async executeTrade(
+    jupiterClient: JupiterClient,
+    inputToken: Token,
+    outputToken: Token,
+    amount: Decimal,
+    enableTrading: boolean,
+  ): Promise<void> {
+    console.log(
+      `Trading ${amount.toString()} ${inputToken.symbol} for ${outputToken.symbol}...`,
+    );
+    const lamports = fromNumberToLamports(amount, inputToken.decimals);
+    const quote = await jupiterClient.getQuote(
+      inputToken.address,
+      outputToken.address,
+      lamports,
+      this.slippageBps,
+    );
+    const swapResponse: SwapResponse =
+      await jupiterClient.getSwapTransaction(quote);
+
+    if (!enableTrading) {
+      console.log("Trading disabled");
+      return;
     }
 
-    /**
-     * Read SPL token decimals from the chain so the hardcoded defaults cannot drift
-     * from the actual mint configuration.
-     * @param connection Solana connection object.
-     */
-    async syncTokenDecimals(connection: Connection): Promise<void> {
-        for (const token of [this.mbcToken, this.usdcToken]) {
-            try {
-                const decimals = await getMintDecimals(connection, token.address);
-                if (decimals !== token.decimals) {
-                    console.warn(`Correcting ${token.symbol} decimals from ${token.decimals} to on-chain value ${decimals}`);
-                    token.decimals = decimals;
-                }
-            } catch (err) {
-                console.warn(`Could not verify ${token.symbol} decimals on-chain, keeping ${token.decimals}:`, err);
-            }
-        }
+    const success = await jupiterClient.executeSwap(swapResponse);
+    if (!success) {
+      console.error(
+        `Swap of ${amount.toString()} ${inputToken.symbol} -> ${outputToken.symbol} failed; balances will be re-evaluated on the next cycle`,
+      );
+    }
+  }
+
+  /**
+   * Determines the necessity of a trade based on the current balance of two tokens and their USD values.
+   * The goal is to keep token0 at `rebalancePercentage` of the total portfolio value, trading only when
+   * the imbalance exceeds `priceTolerance` of the total value and the resulting amount is above
+   * `minimumTradeAmount`.
+   *
+   * @param jupiterClient An instance of JupiterClient used to fetch USD values of tokens.
+   * @param pair An object representing the token pair to be evaluated, containing `token0` and `token1` properties.
+   * @param token0Balance The current balance of `token0`.
+   * @param token1Balance The current balance of `token1`.
+   * @returns A promise that resolves to an object indicating whether a trade is needed and the amount of each token to trade.
+   */
+  async determineTradeNecessity(
+    jupiterClient: JupiterClient,
+    pair: TradePair,
+    token0Balance: Decimal,
+    token1Balance: Decimal,
+  ) {
+    const token0Price = await this.getUSDValue(jupiterClient, pair.token0);
+    const token1Price = await this.getUSDValue(jupiterClient, pair.token1);
+
+    let solAmountToTrade = new Decimal(0);
+    let mbcAmountToTrade = new Decimal(0);
+    let tradeNeeded = false;
+
+    // Without a valid price for both tokens the portfolio cannot be valued.
+    // Surface this explicitly and skip, instead of dividing by zero / letting
+    // the generic catch in runMM swallow it silently every cycle.
+    if (token0Price.lte(0) || token1Price.lte(0)) {
+      console.warn(
+        `Skipping ${pair.token0.symbol}/${pair.token1.symbol}: missing price/route ` +
+          `(${pair.token0.symbol}=${token0Price.toString()}, ${pair.token1.symbol}=${token1Price.toString()})`,
+      );
+      return { tradeNeeded, solAmountToTrade, mbcAmountToTrade };
     }
 
-    /**
-     * Evaluate and execute trade
-     * @param {JupiterClient} jupiterClient - JupiterClient object
-     * @param {TradePair} pair - Pair object
-     * @param {boolean} enableTrading - Enable trading
-     * @returns {Promise<void>} - Promise object
-     */
-    async evaluateAndExecuteTrade(jupiterClient: JupiterClient, pair: TradePair, enableTrading: boolean): Promise<void> {
-        const token0Balance = await this.fetchTokenBalance(jupiterClient, pair.token0);
-        const token1Balance = await this.fetchTokenBalance(jupiterClient, pair.token1);
+    const token0Value = token0Balance.mul(token0Price);
+    const token1Value = token1Balance.mul(token1Price);
 
-        console.log(`Token0 balance (in ${pair.token0.symbol}): ${token0Balance.toString()}`);
-        console.log(`Token1 balance (in ${pair.token1.symbol}): ${token1Balance.toString()}`);
+    const totalPortfolioValue = token0Value.add(token1Value);
+    const targetToken0Value = totalPortfolioValue.mul(this.rebalancePercentage);
+    const targetToken1Value = totalPortfolioValue.sub(targetToken0Value);
+    const toleranceValue = totalPortfolioValue.mul(this.priceTolerance);
 
-        const { tradeNeeded, solAmountToTrade, mbcAmountToTrade } =
-            await this.determineTradeNecessity(jupiterClient, pair, token0Balance, token1Balance);
+    console.log(`${pair.token0.symbol} value: ${token0Value.toString()}`);
+    console.log(`${pair.token1.symbol} value: ${token1Value.toString()}`);
 
-        if (!tradeNeeded) {
-            console.log('No trade needed');
-            return;
-        }
-
-        console.log('Trade needed');
-        if (solAmountToTrade.gt(0)) {
-            await this.executeTrade(jupiterClient, pair.token0, pair.token1, solAmountToTrade, enableTrading);
-        } else if (mbcAmountToTrade.gt(0)) {
-            await this.executeTrade(jupiterClient, pair.token1, pair.token0, mbcAmountToTrade, enableTrading);
-        }
+    let tradeValueUsd = new Decimal(0);
+    if (token0Value.sub(targetToken0Value).gt(toleranceValue)) {
+      // token0 is overweight beyond the tolerance: sell the surplus for token1
+      const valueDiff = token0Value.sub(targetToken0Value);
+      solAmountToTrade = valueDiff.div(token0Price);
+      tradeValueUsd = valueDiff;
+      tradeNeeded = true;
+    } else if (token1Value.sub(targetToken1Value).gt(toleranceValue)) {
+      // token1 is overweight beyond the tolerance: sell the surplus for token0
+      const valueDiff = token1Value.sub(targetToken1Value);
+      mbcAmountToTrade = valueDiff.div(token1Price);
+      tradeValueUsd = valueDiff;
+      tradeNeeded = true;
     }
 
-    /**
-     * Quote and execute a single swap, surfacing failures instead of ignoring them.
-     */
-    private async executeTrade(jupiterClient: JupiterClient, inputToken: Token, outputToken: Token, amount: Decimal, enableTrading: boolean): Promise<void> {
-        console.log(`Trading ${amount.toString()} ${inputToken.symbol} for ${outputToken.symbol}...`);
-        const lamports = fromNumberToLamports(amount, inputToken.decimals);
-        const quote = await jupiterClient.getQuote(inputToken.address, outputToken.address, lamports, this.slippageBps);
-        const swapResponse: SwapResponse = await jupiterClient.getSwapTransaction(quote);
-
-        if (!enableTrading) {
-            console.log('Trading disabled');
-            return;
-        }
-
-        const success = await jupiterClient.executeSwap(swapResponse);
-        if (!success) {
-            console.error(`Swap of ${amount.toString()} ${inputToken.symbol} -> ${outputToken.symbol} failed; balances will be re-evaluated on the next cycle`);
-        }
+    // Compare the trade value in USD (not raw token amounts, which are not
+    // comparable across tokens) against the minimum trade value.
+    if (tradeNeeded && tradeValueUsd.lt(this.minimumTradeValueUsd)) {
+      tradeNeeded = false;
     }
 
-    /**
-     * Determines the necessity of a trade based on the current balance of two tokens and their USD values.
-     * The goal is to keep token0 at `rebalancePercentage` of the total portfolio value, trading only when
-     * the imbalance exceeds `priceTolerance` of the total value and the resulting amount is above
-     * `minimumTradeAmount`.
-     *
-     * @param jupiterClient An instance of JupiterClient used to fetch USD values of tokens.
-     * @param pair An object representing the token pair to be evaluated, containing `token0` and `token1` properties.
-     * @param token0Balance The current balance of `token0`.
-     * @param token1Balance The current balance of `token1`.
-     * @returns A promise that resolves to an object indicating whether a trade is needed and the amount of each token to trade.
-     */
-    async determineTradeNecessity(jupiterClient: JupiterClient, pair: TradePair, token0Balance: Decimal, token1Balance: Decimal) {
-        const token0Price = await this.getUSDValue(jupiterClient, pair.token0);
-        const token1Price = await this.getUSDValue(jupiterClient, pair.token1);
+    return { tradeNeeded, solAmountToTrade, mbcAmountToTrade };
+  }
 
-        let solAmountToTrade = new Decimal(0);
-        let mbcAmountToTrade = new Decimal(0);
-        let tradeNeeded = false;
+  /**
+   * Fetch token balance
+   * @param {JupiterClient} jupiterClient - JupiterClient object
+   * @param {Token} token - Token object
+   * @returns {Promise<Decimal>} - Token balance
+   */
+  async fetchTokenBalance(
+    jupiterClient: JupiterClient,
+    token: Token,
+  ): Promise<Decimal> {
+    const rpc = jupiterClient.getRpc();
+    const walletAddress = jupiterClient.getSigner().address;
 
-        // Without a valid price for both tokens the portfolio cannot be valued.
-        // Surface this explicitly and skip, instead of dividing by zero / letting
-        // the generic catch in runMM swallow it silently every cycle.
-        if (token0Price.lte(0) || token1Price.lte(0)) {
-            console.warn(
-                `Skipping ${pair.token0.symbol}/${pair.token1.symbol}: missing price/route ` +
-                `(${pair.token0.symbol}=${token0Price.toString()}, ${pair.token1.symbol}=${token1Price.toString()})`
-            );
-            return { tradeNeeded, solAmountToTrade, mbcAmountToTrade };
-        }
+    const balance =
+      token.address === SOL_MINT_ADDRESS
+        ? new Decimal(
+            (await rpc.getBalance(walletAddress).send()).value.toString(),
+          )
+        : await this.getSPLTokenBalance(
+            rpc,
+            walletAddress,
+            address(token.address),
+          );
 
-        const token0Value = token0Balance.mul(token0Price);
-        const token1Value = token1Balance.mul(token1Price);
+    return balance.div(new Decimal(10).pow(token.decimals));
+  }
 
-        const totalPortfolioValue = token0Value.add(token1Value);
-        const targetToken0Value = totalPortfolioValue.mul(this.rebalancePercentage);
-        const targetToken1Value = totalPortfolioValue.sub(targetToken0Value);
-        const toleranceValue = totalPortfolioValue.mul(this.priceTolerance);
+  /**
+   * Get SPL token balance in minor units.
+   * @param rpc Solana RPC client.
+   * @param walletAddress Wallet address.
+   * @param tokenMintAddress Token mint address.
+   * @returns Token balance as a Decimal.
+   */
+  async getSPLTokenBalance(
+    rpc: SolanaRpc,
+    walletAddress: Address,
+    tokenMintAddress: Address,
+  ): Promise<Decimal> {
+    const accounts = await rpc
+      .getTokenAccountsByOwner(
+        walletAddress,
+        { programId: TOKEN_PROGRAM_ADDRESS },
+        { encoding: "jsonParsed" },
+      )
+      .send();
+    const mint = tokenMintAddress;
+    // A wallet can hold several token accounts for the same mint (ATA + legacy/extra);
+    // sum them all instead of taking only the first match.
+    return accounts.value
+      .filter((account) => account.account.data.parsed.info.mint === mint)
+      .reduce(
+        (total, account) =>
+          total.add(
+            new Decimal(account.account.data.parsed.info.tokenAmount.amount),
+          ),
+        new Decimal(0),
+      );
+  }
 
-        console.log(`${pair.token0.symbol} value: ${token0Value.toString()}`);
-        console.log(`${pair.token1.symbol} value: ${token1Value.toString()}`);
-
-        let tradeValueUsd = new Decimal(0);
-        if (token0Value.sub(targetToken0Value).gt(toleranceValue)) {
-            // token0 is overweight beyond the tolerance: sell the surplus for token1
-            const valueDiff = token0Value.sub(targetToken0Value);
-            solAmountToTrade = valueDiff.div(token0Price);
-            tradeValueUsd = valueDiff;
-            tradeNeeded = true;
-        } else if (token1Value.sub(targetToken1Value).gt(toleranceValue)) {
-            // token1 is overweight beyond the tolerance: sell the surplus for token0
-            const valueDiff = token1Value.sub(targetToken1Value);
-            mbcAmountToTrade = valueDiff.div(token1Price);
-            tradeValueUsd = valueDiff;
-            tradeNeeded = true;
-        }
-
-        // Compare the trade value in USD (not raw token amounts, which are not
-        // comparable across tokens) against the minimum trade value.
-        if (tradeNeeded && tradeValueUsd.lt(this.minimumTradeValueUsd)) {
-            tradeNeeded = false;
-        }
-
-        return { tradeNeeded, solAmountToTrade, mbcAmountToTrade };
-    }
-
-    /**
-     * Fetch token balance
-     * @param {JupiterClient} jupiterClient - JupiterClient object
-     * @param {Token} token - Token object
-     * @returns {Promise<Decimal>} - Token balance
-     */
-    async fetchTokenBalance(jupiterClient: JupiterClient, token: Token): Promise<Decimal> {
-        const connection = jupiterClient.getConnection();
-        const publicKey = jupiterClient.getUserKeypair().publicKey;
-
-        const balance = token.address === SOL_MINT_ADDRESS
-            ? new Decimal(await connection.getBalance(publicKey))
-            : await this.getSPLTokenBalance(connection, publicKey, new PublicKey(token.address));
-
-        return balance.div(new Decimal(10).pow(token.decimals));
-    }
-
-    /**
-     * Get SPL token balance in minor units.
-     * @param connection Solana connection object.
-     * @param walletAddress Wallet public key.
-     * @param tokenMintAddress Token mint public key.
-     * @returns Token balance as a Decimal.
-     */
-    async getSPLTokenBalance(connection: Connection, walletAddress: PublicKey, tokenMintAddress: PublicKey): Promise<Decimal> {
-        const accounts = await connection.getParsedTokenAccountsByOwner(walletAddress, { programId: TOKEN_PROGRAM_ID });
-        const mint = tokenMintAddress.toBase58();
-        // A wallet can hold several token accounts for the same mint (ATA + legacy/extra);
-        // sum them all instead of taking only the first match.
-        return accounts.value
-            .filter((account) => account.account.data.parsed.info.mint === mint)
-            .reduce((total, account) => total.add(new Decimal(account.account.data.parsed.info.tokenAmount.amount)), new Decimal(0));
-    }
-
-    /**
-     * Get USD value of a token.
-     * @param jupiterClient JupiterClient object.
-     * @param token Token object.
-     * @returns USD value of one token unit as a Decimal.
-     */
-    async getUSDValue(jupiterClient: JupiterClient, token: Token): Promise<Decimal> {
-        // Use a dedicated pricing slippage (0), not the execution slippage, so the
-        // valuation is not skewed by the slippage the bot tolerates when trading.
-        // NOTE: this samples 1 unit and so ignores the price-impact of the real
-        // trade size; a future improvement is Jupiter's dedicated Price API.
-        const quote = await jupiterClient.getQuote(token.address, this.usdcToken.address, fromNumberToLamports(1, token.decimals), PRICE_QUOTE_SLIPPAGE_BPS);
-        return new Decimal(quote.outAmount).div(new Decimal(10).pow(this.usdcToken.decimals));
-    }
+  /**
+   * Get USD value of a token.
+   * @param jupiterClient JupiterClient object.
+   * @param token Token object.
+   * @returns USD value of one token unit as a Decimal.
+   */
+  async getUSDValue(
+    jupiterClient: JupiterClient,
+    token: Token,
+  ): Promise<Decimal> {
+    // Use a dedicated pricing slippage (0), not the execution slippage, so the
+    // valuation is not skewed by the slippage the bot tolerates when trading.
+    // NOTE: this samples 1 unit and so ignores the price-impact of the real
+    // trade size; a future improvement is Jupiter's dedicated Price API.
+    const quote = await jupiterClient.getQuote(
+      token.address,
+      this.usdcToken.address,
+      fromNumberToLamports(1, token.decimals),
+      PRICE_QUOTE_SLIPPAGE_BPS,
+    );
+    return new Decimal(quote.outAmount).div(
+      new Decimal(10).pow(this.usdcToken.decimals),
+    );
+  }
 }

--- a/src/utils/convert.ts
+++ b/src/utils/convert.ts
@@ -1,4 +1,4 @@
-import Decimal from 'decimal.js';
+import { Decimal } from "decimal.js";
 
 /**
  * Converts a readable number of tokens to the smallest unit (e.g., lamports for SOL).
@@ -7,8 +7,11 @@ import Decimal from 'decimal.js';
  * @param {number} decimals - The number of decimals the token uses.
  * @returns {string} - The amount in the smallest unit, as an integer string.
  */
-export function fromNumberToLamports(value: Decimal.Value, decimals: number): string {
-    return new Decimal(value).mul(new Decimal(10).pow(decimals)).toFixed(0);
+export function fromNumberToLamports(
+  value: Decimal.Value,
+  decimals: number,
+): string {
+  return new Decimal(value).mul(new Decimal(10).pow(decimals)).toFixed(0);
 }
 
 /**
@@ -17,6 +20,9 @@ export function fromNumberToLamports(value: Decimal.Value, decimals: number): st
  * @param {number} decimals - The number of decimals the token uses.
  * @returns {Decimal} - The readable amount, fractional part included.
  */
-export function fromLamportsToNumber(value: Decimal.Value, decimals: number): Decimal {
-    return new Decimal(value).div(new Decimal(10).pow(decimals));
+export function fromLamportsToNumber(
+  value: Decimal.Value,
+  decimals: number,
+): Decimal {
+  return new Decimal(value).div(new Decimal(10).pow(decimals));
 }

--- a/src/utils/transactionSender.ts
+++ b/src/utils/transactionSender.ts
@@ -1,16 +1,16 @@
-import {
-  BlockhashWithExpiryBlockHeight,
-  Connection,
-  TransactionExpiredBlockheightExceededError,
-  VersionedTransactionResponse,
-} from "@solana/web3.js";
 import promiseRetry from "promise-retry";
-import { sleep } from "./sleep";
+import type { Base64EncodedWireTransaction, Signature } from "@solana/kit";
+import type { SolanaRpc } from "../api/solana.js";
+import { sleep } from "./sleep.js";
 
 type TransactionSenderAndConfirmationWaiterArgs = {
-  connection: Connection;
-  serializedTransaction: Buffer;
-  blockhashWithExpiryBlockHeight: BlockhashWithExpiryBlockHeight;
+  rpc: SolanaRpc;
+  /** The signed transaction, base64-encoded (kit wire format). */
+  base64Transaction: Base64EncodedWireTransaction;
+  /** Its signature, used to poll for confirmation. */
+  signature: Signature;
+  /** Last block height at which the transaction's blockhash is still valid. */
+  lastValidBlockHeight: bigint;
   /** Skip RPC preflight simulation. Default false = simulate before broadcast. */
   skipPreflight?: boolean;
 };
@@ -23,76 +23,81 @@ const RESEND_INTERVAL_MS = 2000;
 const STATUS_POLL_INTERVAL_MS = 5000;
 
 /**
- * Sends a serialized transaction, keeps re-broadcasting it until it is
- * confirmed or expires, and returns the confirmed transaction (or null when
- * the transaction expired / could not be confirmed in time).
+ * Sends a signed transaction, keeps re-broadcasting it until it is confirmed or
+ * its blockhash expires, and returns the confirmed transaction (or null when the
+ * transaction expired / could not be found in time).
+ *
+ * HTTP-only: confirmation is polled via getSignatureStatuses and expiry is
+ * detected by comparing the current block height with the transaction's last
+ * valid block height — no RPC WebSocket subscription is required.
  */
 export async function transactionSenderAndConfirmationWaiter({
-  connection,
-  serializedTransaction,
-  blockhashWithExpiryBlockHeight,
+  rpc,
+  base64Transaction,
+  signature,
+  lastValidBlockHeight,
   skipPreflight = false,
-}: TransactionSenderAndConfirmationWaiterArgs): Promise<VersionedTransactionResponse | null> {
-  const sendOptions = { skipPreflight };
-  const txid = await connection.sendRawTransaction(
-    serializedTransaction,
-    sendOptions
-  );
+}: TransactionSenderAndConfirmationWaiterArgs) {
+  const sendConfig = {
+    encoding: "base64" as const,
+    skipPreflight,
+    preflightCommitment: CONFIRMATION_COMMITMENT,
+    // Disable node-side retries; we re-broadcast ourselves below.
+    maxRetries: 0n,
+  };
+
+  await rpc.sendTransaction(base64Transaction, sendConfig).send();
 
   const controller = new AbortController();
-  const abortSignal = controller.signal;
   const startTime = Date.now();
 
-  try {
-    // Periodically re-broadcast until confirmed or aborted; RPC nodes drop
-    // transactions under load, so a single send is not reliable.
-    const abortableResender = async () => {
-      while (!abortSignal.aborted) {
-        await sleep(RESEND_INTERVAL_MS);
-        if (abortSignal.aborted) return;
-        try {
-          await connection.sendRawTransaction(serializedTransaction, sendOptions);
-        } catch (e) {
-          console.warn(`Failed to resend transaction: ${e}`);
-        }
+  // Periodically re-broadcast until confirmed or aborted; RPC nodes drop
+  // transactions under load, so a single send is not reliable.
+  const resender = (async () => {
+    while (!controller.signal.aborted) {
+      await sleep(RESEND_INTERVAL_MS);
+      if (controller.signal.aborted) return;
+      try {
+        await rpc.sendTransaction(base64Transaction, sendConfig).send();
+      } catch (e) {
+        console.warn(`Failed to resend transaction: ${e}`);
       }
-    };
-
-    abortableResender().catch((e) => console.warn(`Transaction resender stopped: ${e}`));
-
-    await Promise.race([
-      connection.confirmTransaction(
-        {
-          ...blockhashWithExpiryBlockHeight,
-          signature: txid,
-          abortSignal,
-        },
-        CONFIRMATION_COMMITMENT
-      ),
-      (async () => {
-        // Backstop poller: settles the race on timeout even if
-        // confirmTransaction hangs (e.g. websocket issues).
-        while (!abortSignal.aborted) {
-          await sleep(STATUS_POLL_INTERVAL_MS);
-          if (Date.now() - startTime > MAX_PROCESS_DURATION_MS) {
-            console.warn("Transaction confirmation timed out");
-            return;
-          }
-          const status = await connection.getSignatureStatus(txid, {
-            searchTransactionHistory: false,
-          });
-          const confirmationStatus = status?.value?.confirmationStatus;
-          if (confirmationStatus === "confirmed" || confirmationStatus === "finalized") {
-            return;
-          }
-        }
-      })(),
-    ]);
-  } catch (e) {
-    if (e instanceof TransactionExpiredBlockheightExceededError) {
-      return null;
     }
-    throw e;
+  })();
+  resender.catch((e) => console.warn(`Transaction resender stopped: ${e}`));
+
+  try {
+    while (!controller.signal.aborted) {
+      await sleep(STATUS_POLL_INTERVAL_MS);
+
+      const { value } = await rpc
+        .getSignatureStatuses([signature], { searchTransactionHistory: false })
+        .send();
+      const confirmationStatus = value[0]?.confirmationStatus;
+      if (
+        confirmationStatus === "confirmed" ||
+        confirmationStatus === "finalized"
+      ) {
+        break;
+      }
+
+      // Expiry: once the network is past the blockhash's last valid height and the
+      // transaction still is not confirmed, it can never land — give up.
+      const blockHeight = await rpc.getBlockHeight().send();
+      if (blockHeight > lastValidBlockHeight) {
+        console.warn(
+          "Transaction expired (block height exceeded last valid block height)",
+        );
+        return null;
+      }
+
+      if (Date.now() - startTime > MAX_PROCESS_DURATION_MS) {
+        // Timed out waiting for confirmation; fall through and try to fetch the
+        // transaction anyway — it may have landed between polls.
+        console.warn("Transaction confirmation timed out");
+        break;
+      }
+    }
   } finally {
     controller.abort();
   }
@@ -100,19 +105,22 @@ export async function transactionSenderAndConfirmationWaiter({
   // getTransaction can lag confirmation, so retry a few times before giving up.
   const response = await promiseRetry(
     async (retry) => {
-      const tx = await connection.getTransaction(txid, {
-        commitment: CONFIRMATION_COMMITMENT,
-        maxSupportedTransactionVersion: 0,
-      });
+      const tx = await rpc
+        .getTransaction(signature, {
+          commitment: CONFIRMATION_COMMITMENT,
+          maxSupportedTransactionVersion: 0,
+          encoding: "base64",
+        })
+        .send();
       if (!tx) {
-        retry(new Error(`Transaction ${txid} not found yet`));
+        retry(new Error(`Transaction ${signature} not found yet`));
       }
       return tx;
     },
     {
       retries: 5,
       minTimeout: 3e3,
-    }
+    },
   ).catch(() => null);
 
   return response;

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -1,61 +1,67 @@
-import fs from 'fs';
-import { Keypair } from '@solana/web3.js';
-import { derivePath } from 'ed25519-hd-key';
-import * as bip39 from 'bip39';
-import * as nacl from 'tweetnacl';
-import { homedir } from 'os';
-import * as path from 'path';
+import fs from "fs";
+import { createKeyPairSignerFromBytes, type KeyPairSigner } from "@solana/kit";
+import { derivePath } from "ed25519-hd-key";
+import * as bip39 from "bip39";
+import nacl from "tweetnacl";
+import { homedir } from "os";
+import * as path from "path";
 
-const DEFAULT_KEYPAIR_PATH = path.join(homedir(), '.config/solana/id.json');
+const DEFAULT_KEYPAIR_PATH = path.join(homedir(), ".config/solana/id.json");
 const DEFAULT_DERIVATION_PATH = "m/44'/501'/0'/0'";
 
 /**
- * Load a keypair from a JSON secret-key file (the format produced by `solana-keygen`).
+ * Load a signer from a JSON secret-key file (the format produced by `solana-keygen`:
+ * a 64-byte secret key as a JSON array).
  * @param filePath Path to the JSON keypair file.
- * @returns The loaded keypair.
+ * @returns The loaded signer.
  */
-function loadKeypairFromFile(filePath: string): Keypair {
-    try {
-        const fileContent = fs.readFileSync(filePath, { encoding: 'utf8' });
-        const secretKeyArray = JSON.parse(fileContent);
-        return Keypair.fromSecretKey(Uint8Array.from(secretKeyArray));
-    } catch (error) {
-        const reason = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to load keypair from ${filePath}: ${reason}`);
-    }
+async function loadKeypairFromFile(filePath: string): Promise<KeyPairSigner> {
+  try {
+    const fileContent = fs.readFileSync(filePath, { encoding: "utf8" });
+    const secretKeyArray = JSON.parse(fileContent);
+    return await createKeyPairSignerFromBytes(Uint8Array.from(secretKeyArray));
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load keypair from ${filePath}: ${reason}`);
+  }
 }
 
 /**
- * Derive a keypair from a BIP39 mnemonic using the standard Solana derivation path.
+ * Derive a signer from a BIP39 mnemonic using the standard Solana derivation path.
  * @param mnemonic BIP39 mnemonic phrase.
  * @param derivationPath BIP44 derivation path (defaults to Solana's m/44'/501'/0'/0').
- * @returns The derived keypair.
+ * @returns The derived signer.
  */
-function loadKeypairFromMnemonic(mnemonic: string, derivationPath: string = DEFAULT_DERIVATION_PATH): Keypair {
-    const seed = bip39.mnemonicToSeedSync(mnemonic);
-    const derivedSeed = derivePath(derivationPath, seed.toString('hex')).key;
-    const keypair = nacl.sign.keyPair.fromSeed(derivedSeed);
-    return Keypair.fromSecretKey(new Uint8Array(keypair.secretKey));
+async function loadKeypairFromMnemonic(
+  mnemonic: string,
+  derivationPath: string = DEFAULT_DERIVATION_PATH,
+): Promise<KeyPairSigner> {
+  const seed = bip39.mnemonicToSeedSync(mnemonic);
+  const derivedSeed = derivePath(derivationPath, seed.toString("hex")).key;
+  // tweetnacl produces the 64-byte secret key (32-byte seed || 32-byte public key)
+  // expected by createKeyPairSignerFromBytes.
+  const keypair = nacl.sign.keyPair.fromSeed(derivedSeed);
+  return await createKeyPairSignerFromBytes(new Uint8Array(keypair.secretKey));
 }
 
 /**
- * Load the bot keypair. Resolution order:
+ * Load the bot signer. Resolution order:
  * 1. USER_KEYPAIR - path to a JSON secret-key file
  * 2. SOLANA_MNEMONIC - BIP39 mnemonic phrase
  * 3. ~/.config/solana/id.json - default Solana CLI keypair
- * @returns The loaded keypair.
+ * @returns The loaded signer.
  */
-export function loadKeypair(): Keypair {
-    if (process.env.USER_KEYPAIR) {
-        return loadKeypairFromFile(process.env.USER_KEYPAIR);
-    }
-    if (process.env.SOLANA_MNEMONIC) {
-        return loadKeypairFromMnemonic(process.env.SOLANA_MNEMONIC);
-    }
-    if (fs.existsSync(DEFAULT_KEYPAIR_PATH)) {
-        return loadKeypairFromFile(DEFAULT_KEYPAIR_PATH);
-    }
-    throw new Error(
-        `No keypair found. Set USER_KEYPAIR (path to a JSON keypair file), set SOLANA_MNEMONIC, or create a keypair at ${DEFAULT_KEYPAIR_PATH}`
-    );
+export async function loadKeypair(): Promise<KeyPairSigner> {
+  if (process.env.USER_KEYPAIR) {
+    return loadKeypairFromFile(process.env.USER_KEYPAIR);
+  }
+  if (process.env.SOLANA_MNEMONIC) {
+    return loadKeypairFromMnemonic(process.env.SOLANA_MNEMONIC);
+  }
+  if (fs.existsSync(DEFAULT_KEYPAIR_PATH)) {
+    return loadKeypairFromFile(DEFAULT_KEYPAIR_PATH);
+  }
+  throw new Error(
+    `No keypair found. Set USER_KEYPAIR (path to a JSON keypair file), set SOLANA_MNEMONIC, or create a keypair at ${DEFAULT_KEYPAIR_PATH}`,
+  );
 }

--- a/tests/basicMM.test.ts
+++ b/tests/basicMM.test.ts
@@ -1,161 +1,221 @@
-import { describe, expect, it } from 'vitest';
-import Decimal from 'decimal.js';
-import { Connection, PublicKey } from '@solana/web3.js';
-import { MarketMaker, MarketMakerConfig, TradePair } from '../src/strategies/basicMM';
-import { JupiterClient } from '../src/api/jupiter';
-import { SOL_MINT_ADDRESS, MBC_MINT_ADDRESS } from '../src/constants/constants';
+import { describe, expect, it } from "vitest";
+import { Decimal } from "decimal.js";
+import { address } from "@solana/kit";
+import {
+  MarketMaker,
+  MarketMakerConfig,
+  TradePair,
+} from "../src/strategies/basicMM";
+import { JupiterClient } from "../src/api/jupiter";
+import type { SolanaRpc } from "../src/api/solana";
+import { SOL_MINT_ADDRESS, MBC_MINT_ADDRESS } from "../src/constants/constants";
 
 /**
  * Fake Jupiter client returning fixed USD prices (USDC has 6 decimals):
  * SOL = $100, MBC = $1.
  */
 function fakeJupiterClient(prices: Record<string, number>): JupiterClient {
-    return {
-        getQuote: async (inputMint: string) => ({
-            outAmount: new Decimal(prices[inputMint]).mul(1e6).toFixed(0),
-        }),
-    } as unknown as JupiterClient;
+  return {
+    getQuote: async (inputMint: string) => ({
+      outAmount: new Decimal(prices[inputMint]).mul(1e6).toFixed(0),
+    }),
+  } as unknown as JupiterClient;
 }
 
 const PRICES = { [SOL_MINT_ADDRESS]: 100, [MBC_MINT_ADDRESS]: 1 };
 
-function makeMarketMaker(config: MarketMakerConfig = {}): { mm: MarketMaker; pair: TradePair } {
-    const mm = new MarketMaker(config);
-    return { mm, pair: { token0: mm.solToken, token1: mm.mbcToken } };
+function makeMarketMaker(config: MarketMakerConfig = {}): {
+  mm: MarketMaker;
+  pair: TradePair;
+} {
+  const mm = new MarketMaker(config);
+  return { mm, pair: { token0: mm.solToken, token1: mm.mbcToken } };
 }
 
-describe('MarketMaker config validation', () => {
-    it('rejects a rebalance percentage outside (0,1)', () => {
-        expect(() => new MarketMaker({ rebalancePercentage: 1.5 })).toThrow(/rebalancePercentage/);
-        expect(() => new MarketMaker({ rebalancePercentage: 0 })).toThrow(/rebalancePercentage/);
-    });
+describe("MarketMaker config validation", () => {
+  it("rejects a rebalance percentage outside (0,1)", () => {
+    expect(() => new MarketMaker({ rebalancePercentage: 1.5 })).toThrow(
+      /rebalancePercentage/,
+    );
+    expect(() => new MarketMaker({ rebalancePercentage: 0 })).toThrow(
+      /rebalancePercentage/,
+    );
+  });
 
-    it('rejects a non-integer or out-of-range slippage', () => {
-        expect(() => new MarketMaker({ slippageBps: -1 })).toThrow(/slippageBps/);
-        expect(() => new MarketMaker({ slippageBps: 2000 })).toThrow(/slippageBps/);
-        expect(() => new MarketMaker({ slippageBps: 10.5 })).toThrow(/slippageBps/);
-    });
+  it("rejects a non-integer or out-of-range slippage", () => {
+    expect(() => new MarketMaker({ slippageBps: -1 })).toThrow(/slippageBps/);
+    expect(() => new MarketMaker({ slippageBps: 2000 })).toThrow(/slippageBps/);
+    expect(() => new MarketMaker({ slippageBps: 10.5 })).toThrow(/slippageBps/);
+  });
 
-    it('rejects a non-positive price tolerance and minimum trade amount', () => {
-        expect(() => new MarketMaker({ priceTolerance: 0 })).toThrow(/priceTolerance/);
-        expect(() => new MarketMaker({ minimumTradeValueUsd: 0 })).toThrow(/minimumTradeValueUsd/);
-    });
+  it("rejects a non-positive price tolerance and minimum trade amount", () => {
+    expect(() => new MarketMaker({ priceTolerance: 0 })).toThrow(
+      /priceTolerance/,
+    );
+    expect(() => new MarketMaker({ minimumTradeValueUsd: 0 })).toThrow(
+      /minimumTradeValueUsd/,
+    );
+  });
 
-    it('rejects a wait time below 1000ms', () => {
-        expect(() => new MarketMaker({ waitTime: 500 })).toThrow(/waitTime/);
-    });
+  it("rejects a wait time below 1000ms", () => {
+    expect(() => new MarketMaker({ waitTime: 500 })).toThrow(/waitTime/);
+  });
 
-    it('accepts valid overrides', () => {
-        expect(() => new MarketMaker({ rebalancePercentage: 0.75, slippageBps: 50 })).not.toThrow();
-    });
+  it("accepts valid overrides", () => {
+    expect(
+      () => new MarketMaker({ rebalancePercentage: 0.75, slippageBps: 50 }),
+    ).not.toThrow();
+  });
 });
 
-describe('getSPLTokenBalance', () => {
-    function fakeConnectionWithAccounts(entries: { mint: string; amount: string }[]): Connection {
-        return {
-            getParsedTokenAccountsByOwner: async () => ({
-                value: entries.map((e) => ({
-                    account: { data: { parsed: { info: { mint: e.mint, tokenAmount: { amount: e.amount } } } } },
-                })),
-            }),
-        } as unknown as Connection;
-    }
+describe("getSPLTokenBalance", () => {
+  // Mocks the functional kit RPC: getTokenAccountsByOwner(...).send().
+  function fakeRpcWithAccounts(
+    entries: { mint: string; amount: string }[],
+  ): SolanaRpc {
+    return {
+      getTokenAccountsByOwner: () => ({
+        send: async () => ({
+          value: entries.map((e) => ({
+            account: {
+              data: {
+                parsed: {
+                  info: { mint: e.mint, tokenAmount: { amount: e.amount } },
+                },
+              },
+            },
+          })),
+        }),
+      }),
+    } as unknown as SolanaRpc;
+  }
 
-    it('sums every token account that matches the mint', async () => {
-        const mm = new MarketMaker();
-        const wallet = new PublicKey(SOL_MINT_ADDRESS);
-        const connection = fakeConnectionWithAccounts([
-            { mint: MBC_MINT_ADDRESS, amount: '100' },
-            { mint: MBC_MINT_ADDRESS, amount: '250' },
-            { mint: SOL_MINT_ADDRESS, amount: '999' }, // different mint, must be ignored
-        ]);
-        const balance = await mm.getSPLTokenBalance(connection, wallet, new PublicKey(MBC_MINT_ADDRESS));
-        expect(balance.toString()).toBe('350');
-    });
+  it("sums every token account that matches the mint", async () => {
+    const mm = new MarketMaker();
+    const wallet = address(SOL_MINT_ADDRESS);
+    const rpc = fakeRpcWithAccounts([
+      { mint: MBC_MINT_ADDRESS, amount: "100" },
+      { mint: MBC_MINT_ADDRESS, amount: "250" },
+      { mint: SOL_MINT_ADDRESS, amount: "999" }, // different mint, must be ignored
+    ]);
+    const balance = await mm.getSPLTokenBalance(
+      rpc,
+      wallet,
+      address(MBC_MINT_ADDRESS),
+    );
+    expect(balance.toString()).toBe("350");
+  });
 
-    it('returns 0 when no account matches the mint', async () => {
-        const mm = new MarketMaker();
-        const wallet = new PublicKey(SOL_MINT_ADDRESS);
-        const connection = fakeConnectionWithAccounts([{ mint: SOL_MINT_ADDRESS, amount: '10' }]);
-        const balance = await mm.getSPLTokenBalance(connection, wallet, new PublicKey(MBC_MINT_ADDRESS));
-        expect(balance.toString()).toBe('0');
-    });
+  it("returns 0 when no account matches the mint", async () => {
+    const mm = new MarketMaker();
+    const wallet = address(SOL_MINT_ADDRESS);
+    const rpc = fakeRpcWithAccounts([{ mint: SOL_MINT_ADDRESS, amount: "10" }]);
+    const balance = await mm.getSPLTokenBalance(
+      rpc,
+      wallet,
+      address(MBC_MINT_ADDRESS),
+    );
+    expect(balance.toString()).toBe("0");
+  });
 });
 
-describe('determineTradeNecessity', () => {
-    it('does not trade a balanced portfolio', async () => {
-        const { mm, pair } = makeMarketMaker();
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient(PRICES), pair, new Decimal(1), new Decimal(100)
-        );
-        expect(result.tradeNeeded).toBe(false);
-    });
+describe("determineTradeNecessity", () => {
+  it("does not trade a balanced portfolio", async () => {
+    const { mm, pair } = makeMarketMaker();
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient(PRICES),
+      pair,
+      new Decimal(1),
+      new Decimal(100),
+    );
+    expect(result.tradeNeeded).toBe(false);
+  });
 
-    it('sells the SOL surplus when SOL is overweight', async () => {
-        const { mm, pair } = makeMarketMaker();
-        // SOL: 2 * $100 = $200, MBC: 100 * $1 = $100 -> surplus $50 -> 0.5 SOL
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient(PRICES), pair, new Decimal(2), new Decimal(100)
-        );
-        expect(result.tradeNeeded).toBe(true);
-        expect(result.solAmountToTrade.toNumber()).toBeCloseTo(0.5);
-        expect(result.mbcAmountToTrade.toNumber()).toBe(0);
-    });
+  it("sells the SOL surplus when SOL is overweight", async () => {
+    const { mm, pair } = makeMarketMaker();
+    // SOL: 2 * $100 = $200, MBC: 100 * $1 = $100 -> surplus $50 -> 0.5 SOL
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient(PRICES),
+      pair,
+      new Decimal(2),
+      new Decimal(100),
+    );
+    expect(result.tradeNeeded).toBe(true);
+    expect(result.solAmountToTrade.toNumber()).toBeCloseTo(0.5);
+    expect(result.mbcAmountToTrade.toNumber()).toBe(0);
+  });
 
-    it('sells the MBC surplus when MBC is overweight', async () => {
-        const { mm, pair } = makeMarketMaker();
-        // SOL: $100, MBC: $300 -> surplus $100 -> 100 MBC
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient(PRICES), pair, new Decimal(1), new Decimal(300)
-        );
-        expect(result.tradeNeeded).toBe(true);
-        expect(result.mbcAmountToTrade.toNumber()).toBeCloseTo(100);
-        expect(result.solAmountToTrade.toNumber()).toBe(0);
-    });
+  it("sells the MBC surplus when MBC is overweight", async () => {
+    const { mm, pair } = makeMarketMaker();
+    // SOL: $100, MBC: $300 -> surplus $100 -> 100 MBC
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient(PRICES),
+      pair,
+      new Decimal(1),
+      new Decimal(300),
+    );
+    expect(result.tradeNeeded).toBe(true);
+    expect(result.mbcAmountToTrade.toNumber()).toBeCloseTo(100);
+    expect(result.solAmountToTrade.toNumber()).toBe(0);
+  });
 
-    it('does not trade when the imbalance is within the price tolerance', async () => {
-        const { mm, pair } = makeMarketMaker();
-        // SOL: $102, MBC: $100 -> imbalance $1 vs tolerance 2% of $202 = $4.04
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient(PRICES), pair, new Decimal(1.02), new Decimal(100)
-        );
-        expect(result.tradeNeeded).toBe(false);
-    });
+  it("does not trade when the imbalance is within the price tolerance", async () => {
+    const { mm, pair } = makeMarketMaker();
+    // SOL: $102, MBC: $100 -> imbalance $1 vs tolerance 2% of $202 = $4.04
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient(PRICES),
+      pair,
+      new Decimal(1.02),
+      new Decimal(100),
+    );
+    expect(result.tradeNeeded).toBe(false);
+  });
 
-    it('does not trade below the minimum trade value', async () => {
-        const { mm, pair } = makeMarketMaker({ minimumTradeValueUsd: 100 });
-        // Surplus is 0.5 SOL = $50, below the configured minimum of $100
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient(PRICES), pair, new Decimal(2), new Decimal(100)
-        );
-        expect(result.tradeNeeded).toBe(false);
-    });
+  it("does not trade below the minimum trade value", async () => {
+    const { mm, pair } = makeMarketMaker({ minimumTradeValueUsd: 100 });
+    // Surplus is 0.5 SOL = $50, below the configured minimum of $100
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient(PRICES),
+      pair,
+      new Decimal(2),
+      new Decimal(100),
+    );
+    expect(result.tradeNeeded).toBe(false);
+  });
 
-    it('does not trade (and does not throw) when a token has no price/route', async () => {
-        const { mm, pair } = makeMarketMaker();
-        // MBC priced at 0 -> missing route; must skip without dividing by zero
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient({ [SOL_MINT_ADDRESS]: 100, [MBC_MINT_ADDRESS]: 0 }),
-            pair, new Decimal(2), new Decimal(100)
-        );
-        expect(result.tradeNeeded).toBe(false);
-    });
+  it("does not trade (and does not throw) when a token has no price/route", async () => {
+    const { mm, pair } = makeMarketMaker();
+    // MBC priced at 0 -> missing route; must skip without dividing by zero
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient({ [SOL_MINT_ADDRESS]: 100, [MBC_MINT_ADDRESS]: 0 }),
+      pair,
+      new Decimal(2),
+      new Decimal(100),
+    );
+    expect(result.tradeNeeded).toBe(false);
+  });
 
-    it('honours a custom rebalance percentage', async () => {
-        const { mm, pair } = makeMarketMaker({ rebalancePercentage: 0.75 });
-        // Target: SOL 75% / MBC 25%. SOL $100, MBC $100 -> MBC overweight by $50
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient(PRICES), pair, new Decimal(1), new Decimal(100)
-        );
-        expect(result.tradeNeeded).toBe(true);
-        expect(result.mbcAmountToTrade.toNumber()).toBeCloseTo(50);
-    });
+  it("honours a custom rebalance percentage", async () => {
+    const { mm, pair } = makeMarketMaker({ rebalancePercentage: 0.75 });
+    // Target: SOL 75% / MBC 25%. SOL $100, MBC $100 -> MBC overweight by $50
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient(PRICES),
+      pair,
+      new Decimal(1),
+      new Decimal(100),
+    );
+    expect(result.tradeNeeded).toBe(true);
+    expect(result.mbcAmountToTrade.toNumber()).toBeCloseTo(50);
+  });
 
-    it('does not trade an empty portfolio', async () => {
-        const { mm, pair } = makeMarketMaker();
-        const result = await mm.determineTradeNecessity(
-            fakeJupiterClient(PRICES), pair, new Decimal(0), new Decimal(0)
-        );
-        expect(result.tradeNeeded).toBe(false);
-    });
+  it("does not trade an empty portfolio", async () => {
+    const { mm, pair } = makeMarketMaker();
+    const result = await mm.determineTradeNecessity(
+      fakeJupiterClient(PRICES),
+      pair,
+      new Decimal(0),
+      new Decimal(0),
+    );
+    expect(result.tradeNeeded).toBe(false);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,19 @@
 {
-    "compilerOptions": {
-        "target": "es6",
-        "module": "commonjs",
-        "strict": true,
-        "esModuleInterop": true,
-        "forceConsistentCasingInFileNames": true,
-        "outDir": "dist",
-        "rootDir": "src",
-        "resolveJsonModule": true,
-        "skipLibCheck": true,
-        "lib": [
-            "es2020"
-        ],
-        "sourceMap": true,
-        "declaration": true
-    },
-    "include": [
-        "src/**/*.ts"
-    ],
-    "exclude": [
-        "node_modules",
-        "dist",
-        "tests"
-    ]
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "lib": ["es2023"],
+    "sourceMap": true,
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
 }


### PR DESCRIPTION
## Cosa
Migrazione completa dallo stack classico **@solana/web3.js 1.x + @solana/spl-token** al moderno **@solana/kit (v6.10) + @solana-program/token**, con passaggio a **ESM** e bump dell'intera toolchain.

## Perché
Dopo il bump di `vitest` restavano **8 advisory** (3 high, 5 moderate) tutte transitive dell'ecosistema Solana classico (`bigint-buffer` senza patch upstream, `uuid@8` via `jayson`), non risolvibili con un bump non-breaking. Lo stack kit non le porta: **`npm audit` → 0**.

## Modifiche principali
- **ESM**: `"type": "module"`, tsconfig `nodenext` + `target es2022`, import interni con `.js`; dev runner `ts-node` → `tsx`.
- **RPC read-path**: client funzionale kit (`createSolanaRpc`; `getAccountInfo`/`getBalance`/`getTokenAccountsByOwner`). `PublicKey` → `Address`; `TOKEN_PROGRAM_ID` → `@solana-program/token`.
- **Wallet**: `KeyPairSigner` async (`createKeyPairSignerFromBytes`); catena di derivazione BIP39 (bip39 + ed25519-hd-key + tweetnacl) **invariata**.
- **executeSwap**: `getTransactionDecoder` → `signTransaction` → `getBase64EncodedWireTransaction` → `sendTransaction`.
- **transactionSender**: loop confirm/resend **HTTP-only** (`getSignatureStatuses` + `getBlockHeight` per l'expiry); **nessuna** subscription WebSocket introdotta.
- `fetch` nativo (rimosso `cross-fetch`); rimossa dep morta `bs58`.
- Toolchain: TypeScript 6, ESLint 10, Vitest 4, @types/node 24, dotenv 17, ed25519-hd-key 2. `engines.node >= 20` (kit usa WebCrypto Ed25519).
- CI: matrice Node **20 & 22** + gate `npm audit --audit-level=high`.

## Fix pre-esistente
L'endpoint Jupiter di default `quote-api.jup.ag/v6` **non risolve più** (deprecato). Default aggiornato al free tier corrente **`lite-api.jup.ag/swap/v1`** (paid: `api.jup.ag/swap/v1`).

## Verifica
- ✅ `tsc` build, **20/20** vitest, eslint, **0** advisory.
- ✅ Path decode→sign→serialize validato su una **swap tx Jupiter reale** via `simulateTransaction(sigVerify:true)`: la firma verifica (solo `AccountNotFound` sulla chiave di test senza fondi).
- ⏳ **Gate umano prima del merge**: micro-swap reale su mainnet con importo minimo per validare broadcast+confirm in condizioni reali.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated app setup to use modern Node.js and ESM support.
  * Added broader CI coverage across Node 20 and 22.

* **Bug Fixes**
  * Improved wallet, Solana, and swap handling for better reliability.
  * Updated default API endpoint guidance to the current free-tier swap URL.

* **Documentation**
  * Refreshed README and contributor notes to match the new runtime, tooling, and environment setup.

* **Chores**
  * Upgraded dependencies and added automated vulnerability checks in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->